### PR TITLE
Make hero overlay scroll to reveal R

### DIFF
--- a/src/components/homepage/Hero.tsx
+++ b/src/components/homepage/Hero.tsx
@@ -31,7 +31,7 @@ const HeroSection: React.FC<HeroProps> = ({ headline, subheadline, ctaText, ctaL
     target: heroRef,
     offset: ['start start', 'end start'],
   });
-  const overlayY = useTransform(scrollYProgress, [0, 1], ['0%', '-40%']);
+  const overlayY = useTransform(scrollYProgress, [0, 1], ['0%', '-95%']);
 
   const searchParams = useSearchParams();
   const controls = useAnimation();
@@ -173,22 +173,21 @@ const HeroSection: React.FC<HeroProps> = ({ headline, subheadline, ctaText, ctaL
         </motion.div>
       </div>
 
-      <div className="pointer-events-none absolute top-1/2 right-[25%] z-20 hidden -translate-y-1/2 md:flex">
+      <div className="pointer-events-none absolute top-0 right-[25%] z-20 hidden h-[95%] overflow-hidden md:flex">
         <motion.div
           ref={overlayRef}
-          style={{ y: overlayY, rotate: -90 }}
+          style={{ y: overlayY }}
           initial="hidden"
           animate="visible"
-          variants={{ visible: { transition: { staggerChildren: 0.15, delayChildren: 0.3 } } }}
-          className="flex flex-col items-center gap-1"
+          className="flex h-[195%] flex-col items-center justify-between"
         >
           {['N', 'P', 'R'].map((letter) => (
             <motion.span
               key={letter}
-              style={{ rotate: 90, fontSize: 'clamp(2rem,8vw,6rem)' }}
+              style={{ fontSize: 'clamp(2rem,8vw,6rem)' }}
               variants={{ hidden: { opacity: 0, y: -20 }, visible: { opacity: 0.6, y: 0 } }}
               transition={{ duration: 0.6 }}
-              className="block font-extrabold text-[#f2f3f4]/40 leading-none"
+              className="block font-extrabold text-[#d4af37] leading-none"
             >
               {letter}
             </motion.span>


### PR DESCRIPTION
## Summary
- allow overlay letters to scroll so N is replaced by R
- stretch overlay to 95% height with overflow hidden

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6848b0120e548328b69eda0e7f2a632f