### PR TITLE
Rebuild pricing section with quote modal

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,7 @@ import StickyHeader from '@/components/global/Header';
 import HeroSection from '@/components/homepage/Hero';
 import { hero } from '@/content/homepage/hero';
 import IndustryTemplatesSection from '@/components/homepage/IndustryTemplates';
-import TabbedPricing from '@/components/homepage/PricingSection';
+import PricingSection from '@/components/homepage/PricingSection';
 import FooterSection from '@/components/global/Footer';
 import WhyTrustSection from '@/components/homepage/WhyTrustSection';
 import ContactSection from '@/components/homepage/ContactSection';
@@ -17,18 +17,18 @@ export default function Page() {
 
   return (
     <section>
-    <StickyHeader />
-    <main key={pathname} className="relative w-full overflow-x-hidden bg-white text-black">
+      <StickyHeader />
+      <main key={pathname} className="relative w-full overflow-x-hidden bg-white text-black">
         <Suspense>
           <HeroSection {...hero} />
         </Suspense>
         <IndustryTemplatesSection />
-        <TabbedPricing />
+        <PricingSection />
         <WhyTrustSection />
         <ContactSection />
         <FinalCtaSection />
-    </main>
-    <FooterSection />
-    </section>  
+      </main>
+      <FooterSection />
+    </section>
   );
 }

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -1,15 +1,15 @@
-import StickyHeader from '@/components/global/Header'
-import FooterSection from '@/components/global/Footer'
-import TabbedPricing from '@/components/homepage/PricingSection'
+import StickyHeader from '@/components/global/Header';
+import FooterSection from '@/components/global/Footer';
+import PricingSection from '@/components/homepage/PricingSection';
 
 export default function PricingPage() {
   return (
     <section>
       <StickyHeader />
       <main className="relative w-full overflow-x-hidden bg-white text-black">
-        <TabbedPricing />
+        <PricingSection />
       </main>
       <FooterSection />
     </section>
-  )
+  );
 }

--- a/src/components/homepage/PricingSection.tsx
+++ b/src/components/homepage/PricingSection.tsx
@@ -2,14 +2,11 @@
 
 import { pricing } from '@/content/homepage/pricing';
 import { Card, CardContent } from '@/components/ui/card';
+import QuoteModal from './QuoteModal';
 import { motion } from 'framer-motion';
-import { ArrowRight, Info } from 'lucide-react';
+import { ArrowRight } from 'lucide-react';
 
-export default function TabbedPricing() {
-  const webDev = pricing.find((p) => p.category === 'Web Development');
-
-  if (!webDev) return null;
-
+export default function PricingSection() {
   return (
     <section
       id="pricing"
@@ -18,24 +15,23 @@ export default function TabbedPricing() {
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <div className="mx-auto max-w-4xl space-y-4 text-center">
           <h2 className="text-[clamp(1.75rem,3.5vw,2.5rem)] font-bold tracking-tight text-[var(--color-text-light)]">
-            Web Development Packages
+            Our Packages
           </h2>
-          <p className="text-[clamp(0.9rem,1.6vw,1.125rem)] text-[var(--color-gray-300)]">{webDev.headline}</p>
-          <p className="text-[clamp(0.75rem,1.2vw,0.9rem)] text-[var(--color-gray-400)]">
-            Trusted by 120+ teams worldwide
+          <p className="text-[clamp(0.9rem,1.6vw,1.125rem)] text-[var(--color-gray-300)]">
+            {pricing.headline}
           </p>
         </div>
 
         <div className="mx-auto mt-16 max-w-7xl px-4 sm:px-6 lg:px-8">
           <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
-            {webDev.tiers.map((tier, index) => {
-              const isMiddleCard = index === 1;
+            {pricing.tiers.map((tier, index) => {
+              const isMiddleCard = tier.highlight;
               return (
                 <motion.div
                   key={index}
                   whileHover={{ scale: 1.03 }}
                   transition={{ type: 'spring', stiffness: 260, delay: index * 0.1 }}
-                  className={`${isMiddleCard ? 'relative z-10 scale-[1.01]' : ''}`}
+                  className={isMiddleCard ? 'relative z-10 scale-[1.01]' : ''}
                 >
                   {isMiddleCard && (
                     <motion.div
@@ -44,33 +40,26 @@ export default function TabbedPricing() {
                       transition={{ duration: 5, repeat: Infinity }}
                       style={{
                         background:
-                          'radial-gradient(circle, rgba(var(--color-accent-rgb), 0.45), transparent)',
+                          'radial-gradient(circle, rgba(var(--color-accent-rgb),0.45), transparent)',
                       }}
                     />
                   )}
                   <div
-                    className={`relative rounded-2xl ${
-                      isMiddleCard ? 'animate-pulse ring-2 ring-[var(--color-accent)]' : ''
-                    }`}
+                    className={`relative rounded-2xl ${isMiddleCard ? 'animate-pulse ring-2 ring-[var(--color-accent)]' : ''}`}
                   >
                     <Card className="relative flex h-full flex-col justify-between overflow-hidden rounded-2xl border border-[var(--color-gray-600)] bg-[var(--color-card)] shadow-[0_0_0_1px_rgba(0,0,0,0.05),0_10px_15px_-3px_rgba(0,0,0,0.1),0_4px_6px_-4px_rgba(0,0,0,0.1)] backdrop-blur-lg transition-shadow hover:shadow-xl dark:hover:shadow-zinc-900/30">
                       <CardContent className="space-y-4 p-5">
                         <div className="space-y-1">
                           <div className="flex items-center justify-between">
-                            <div className="flex items-center gap-2">
-                              <h3 className="text-[clamp(1rem,1.8vw,1.25rem)] leading-tight font-semibold text-[var(--color-text-light)]">
-                                {tier.title}
-                              </h3>
-                            </div>
+                            <h3 className="text-[clamp(1rem,1.8vw,1.25rem)] leading-tight font-semibold text-[var(--color-text-light)]">
+                              {tier.title}
+                            </h3>
                             <p className="text-[clamp(1rem,1.8vw,1.25rem)] font-bold whitespace-nowrap text-[var(--color-gray-300)]">
                               {tier.price}
                             </p>
                           </div>
                           <p className="text-[clamp(0.8rem,1.2vw,0.9rem)] text-[var(--color-gray-400)] italic">
-                            {index === 0 &&
-                              'Best for early-stage launches or proof-of-concept MVPs.'}
-                            {index === 1 && 'Ideal for growth-focused startups scaling systems.'}
-                            {index === 2 && 'Perfect for high-touch execution or advisory support.'}
+                            {tier.microcopy}
                           </p>
                         </div>
                         <ul className="scrollbar-thin scrollbar-thumb-[var(--color-gray-700)] max-h-[180px] space-y-2 overflow-y-auto text-[clamp(0.8rem,1.2vw,0.9rem)] text-[var(--color-gray-300)]">
@@ -88,15 +77,9 @@ export default function TabbedPricing() {
                         </ul>
                         <div className="pt-2">
                           <button className="group mt-4 inline-flex w-full items-center justify-center gap-2 rounded-full border border-[var(--color-gray-600)] bg-[var(--color-card)] px-[clamp(1rem,2.5vw,1.25rem)] py-[clamp(0.6rem,1.2vw,0.75rem)] text-[clamp(0.8rem,1vw,0.9rem)] font-medium text-[var(--color-text-light)] shadow-sm transition hover:scale-105 hover:bg-[var(--color-gray-700)]">
-                            Start Plan
+                            {tier.cta}
                             <ArrowRight className="h-4 w-4 opacity-70 transition-transform group-hover:translate-x-1 group-hover:opacity-100" />
                           </button>
-                          <p className="mt-1 flex items-center justify-center gap-1 text-center text-[clamp(0.7rem,1vw,0.8rem)] text-[var(--color-gray-400)] italic">
-                            <Info className="h-3 w-3 opacity-70" />
-                            {index === 0 && 'Launch Website Plan'}
-                            {index === 1 && 'Funnel Setup Plan'}
-                            {index === 2 && 'Full System Build'}
-                          </p>
                         </div>
                       </CardContent>
                     </Card>
@@ -104,6 +87,13 @@ export default function TabbedPricing() {
                 </motion.div>
               );
             })}
+          </div>
+
+          <div className="mx-auto mt-16 max-w-xl space-y-4 text-center">
+            <p className="text-[clamp(0.9rem,1.6vw,1.125rem)] font-semibold">
+              Need a scalable, enterprise-grade solution?
+            </p>
+            <QuoteModal />
           </div>
         </div>
       </div>

--- a/src/components/homepage/PricingSection.tsx
+++ b/src/components/homepage/PricingSection.tsx
@@ -23,7 +23,9 @@ export default function PricingSection() {
         </div>
 
         <div className="mx-auto mt-16 max-w-7xl px-4 sm:px-6 lg:px-8">
-          <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+          <div
+            className="flex snap-x snap-mandatory gap-6 overflow-x-auto md:grid md:grid-cols-2 lg:grid-cols-3"
+          >
             {pricing.tiers.map((tier, index) => {
               const isMiddleCard = tier.highlight;
               return (
@@ -31,7 +33,7 @@ export default function PricingSection() {
                   key={index}
                   whileHover={{ scale: 1.03 }}
                   transition={{ type: 'spring', stiffness: 260, delay: index * 0.1 }}
-                  className={isMiddleCard ? 'relative z-10 scale-[1.01]' : ''}
+                  className={`${isMiddleCard ? 'relative z-10 scale-[1.01]' : ''} min-w-[85%] flex-shrink-0 snap-start`}
                 >
                   {isMiddleCard && (
                     <motion.div
@@ -60,6 +62,9 @@ export default function PricingSection() {
                           </div>
                           <p className="text-[clamp(0.8rem,1.2vw,0.9rem)] text-[var(--color-gray-400)] italic">
                             {tier.microcopy}
+                          </p>
+                          <p className="text-[clamp(0.8rem,1.2vw,0.9rem)] text-[var(--color-gray-300)]">
+                            {tier.description}
                           </p>
                         </div>
                         <ul className="scrollbar-thin scrollbar-thumb-[var(--color-gray-700)] max-h-[180px] space-y-2 overflow-y-auto text-[clamp(0.8rem,1.2vw,0.9rem)] text-[var(--color-gray-300)]">

--- a/src/components/homepage/PricingSection.tsx
+++ b/src/components/homepage/PricingSection.tsx
@@ -23,9 +23,7 @@ export default function PricingSection() {
         </div>
 
         <div className="mx-auto mt-16 max-w-7xl px-4 sm:px-6 lg:px-8">
-          <div
-            className="flex snap-x snap-mandatory gap-6 overflow-x-auto md:grid md:grid-cols-2 lg:grid-cols-3"
-          >
+          <div className="flex snap-x snap-mandatory gap-6 overflow-x-auto md:grid md:grid-cols-2 lg:grid-cols-3">
             {pricing.tiers.map((tier, index) => {
               const isMiddleCard = tier.highlight;
               return (
@@ -41,13 +39,11 @@ export default function PricingSection() {
                       animate={{ opacity: [0.2, 0.4, 0.2] }}
                       transition={{ duration: 5, repeat: Infinity }}
                       style={{
-                        background:
-                          'radial-gradient(circle, rgba(var(--color-accent-rgb),0.45), transparent)',
+                        background: 'radial-gradient(circle, rgba(var(--color-accent-rgb),0.45), transparent)',
                       }}
                     />
                   )}
-                  <div
-                    className={`relative rounded-2xl ${isMiddleCard ? 'animate-pulse ring-2 ring-[var(--color-accent)]' : ''}`}
+                  <div className={`relative rounded-2xl ${isMiddleCard ? 'animate-pulse ring-2 ring-[var(--color-accent)]' : ''}`}
                   >
                     <Card className="relative flex h-full flex-col justify-between overflow-hidden rounded-2xl border border-[var(--color-gray-600)] bg-[var(--color-card)] shadow-[0_0_0_1px_rgba(0,0,0,0.05),0_10px_15px_-3px_rgba(0,0,0,0.1),0_4px_6px_-4px_rgba(0,0,0,0.1)] backdrop-blur-lg transition-shadow hover:shadow-xl dark:hover:shadow-zinc-900/30">
                       <CardContent className="space-y-4 p-5">
@@ -73,10 +69,7 @@ export default function PricingSection() {
                               key={i}
                               className={`flex items-start gap-2 ${i === 0 ? 'font-semibold text-[var(--color-text-light)]' : ''}`}
                             >
-                              <span className="text-[var(--color-accent)]">
-                                {i === 0 ? '✅' : '✓'}
-                              </span>{' '}
-                              {feature}
+                              <span className="text-[var(--color-accent)]">{i === 0 ? '✅' : '✓'}</span> {feature}
                             </li>
                           ))}
                         </ul>

--- a/src/components/homepage/QuoteModal.tsx
+++ b/src/components/homepage/QuoteModal.tsx
@@ -70,11 +70,7 @@ export default function QuoteModal({
               </label>
               <label className="block text-sm">
                 Details
-                <textarea
-                  className="mt-1 w-full rounded border px-2 py-1"
-                  rows={3}
-                  required
-                ></textarea>
+                <textarea className="mt-1 w-full rounded border px-2 py-1" rows={3} required></textarea>
               </label>
               <button type="submit" className="mt-2 w-full rounded bg-black px-4 py-2 text-white">
                 Send Request

--- a/src/components/homepage/QuoteModal.tsx
+++ b/src/components/homepage/QuoteModal.tsx
@@ -2,6 +2,7 @@
 
 import * as Dialog from '@radix-ui/react-dialog';
 import { useState } from 'react';
+import { X, CheckCircle2 } from 'lucide-react';
 
 export default function QuoteModal({
   triggerLabel = 'Request a Quote',
@@ -16,7 +17,7 @@ export default function QuoteModal({
   };
 
   return (
-    <Dialog.Root>
+    <Dialog.Root onOpenChange={() => setSubmitted(false)}>
       <Dialog.Trigger asChild>
         <button className="inline-flex items-center justify-center rounded-full bg-white px-6 py-2 text-sm font-semibold text-black shadow hover:bg-gray-200">
           {triggerLabel}
@@ -26,10 +27,17 @@ export default function QuoteModal({
         <Dialog.Overlay className="fixed inset-0 bg-black/50" />
         <Dialog.Content className="fixed top-1/2 left-1/2 w-[90vw] max-w-md -translate-x-1/2 -translate-y-1/2 rounded-xl bg-white p-6 text-black shadow-lg">
           <Dialog.Title className="text-lg font-semibold">Tell us what you need</Dialog.Title>
+          <Dialog.Description className="text-sm text-gray-600">
+            Your submission is reviewed by our founder — not a sales bot.
+          </Dialog.Description>
+          <Dialog.Close className="absolute right-3 top-3 rounded p-1 text-gray-700 hover:bg-gray-100">
+            <X className="h-4 w-4" />
+          </Dialog.Close>
           {submitted ? (
-            <p className="mt-4 text-center text-sm">
-              We&apos;ll respond within 24h with next steps.
-            </p>
+            <div className="mt-4 flex flex-col items-center space-y-2">
+              <CheckCircle2 className="h-8 w-8 text-green-600" />
+              <p className="text-center text-sm">We&apos;ll respond within 24h with next steps.</p>
+            </div>
           ) : (
             <form onSubmit={handleSubmit} className="mt-4 space-y-3">
               <label className="block text-sm">
@@ -71,9 +79,6 @@ export default function QuoteModal({
               <button type="submit" className="mt-2 w-full rounded bg-black px-4 py-2 text-white">
                 Send Request
               </button>
-              <p className="mt-2 text-center text-xs text-gray-600">
-                Your submission is reviewed by our founder — not a sales bot.
-              </p>
             </form>
           )}
         </Dialog.Content>

--- a/src/components/homepage/QuoteModal.tsx
+++ b/src/components/homepage/QuoteModal.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import * as Dialog from '@radix-ui/react-dialog';
+import { useState } from 'react';
+
+export default function QuoteModal({
+  triggerLabel = 'Request a Quote',
+}: {
+  triggerLabel?: string;
+}) {
+  const [submitted, setSubmitted] = useState(false);
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setSubmitted(true);
+  };
+
+  return (
+    <Dialog.Root>
+      <Dialog.Trigger asChild>
+        <button className="inline-flex items-center justify-center rounded-full bg-white px-6 py-2 text-sm font-semibold text-black shadow hover:bg-gray-200">
+          {triggerLabel}
+        </button>
+      </Dialog.Trigger>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/50" />
+        <Dialog.Content className="fixed top-1/2 left-1/2 w-[90vw] max-w-md -translate-x-1/2 -translate-y-1/2 rounded-xl bg-white p-6 text-black shadow-lg">
+          <Dialog.Title className="text-lg font-semibold">Tell us what you need</Dialog.Title>
+          {submitted ? (
+            <p className="mt-4 text-center text-sm">
+              We&apos;ll respond within 24h with next steps.
+            </p>
+          ) : (
+            <form onSubmit={handleSubmit} className="mt-4 space-y-3">
+              <label className="block text-sm">
+                Project Type
+                <select className="mt-1 w-full rounded border px-2 py-1" required>
+                  <option value="website">Website</option>
+                  <option value="automation">Automation</option>
+                  <option value="other">Other</option>
+                </select>
+              </label>
+              <label className="block text-sm">
+                Budget Range
+                <select className="mt-1 w-full rounded border px-2 py-1">
+                  <option value="4-7k">$4K – $7K</option>
+                  <option value="7-10k">$7K – $10K</option>
+                  <option value="10k+">$10K+</option>
+                </select>
+              </label>
+              <label className="block text-sm">
+                Business Type / Industry
+                <input className="mt-1 w-full rounded border px-2 py-1" required />
+              </label>
+              <label className="block text-sm">
+                Desired Launch Timeline
+                <select className="mt-1 w-full rounded border px-2 py-1">
+                  <option value="asap">ASAP</option>
+                  <option value="1month">1 Month</option>
+                  <option value="3months">3 Months</option>
+                </select>
+              </label>
+              <label className="block text-sm">
+                Details
+                <textarea
+                  className="mt-1 w-full rounded border px-2 py-1"
+                  rows={3}
+                  required
+                ></textarea>
+              </label>
+              <button type="submit" className="mt-2 w-full rounded bg-black px-4 py-2 text-white">
+                Send Request
+              </button>
+              <p className="mt-2 text-center text-xs text-gray-600">
+                Your submission is reviewed by our founder — not a sales bot.
+              </p>
+            </form>
+          )}
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -47,11 +47,4 @@ export const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<
 )
 CardFooter.displayName = 'CardFooter'
 
-export {
-  Card,
-  CardHeader,
-  CardTitle,
-  CardDescription,
-  CardContent,
-  CardFooter,
-}
+

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,20 +1,57 @@
+import * as React from 'react'
 import { cn } from '@/lib/utils'
-import { HTMLAttributes, forwardRef } from 'react'
 
-type CardProps = HTMLAttributes<HTMLDivElement>
+type CardProps = React.HTMLAttributes<HTMLDivElement>
 
-export const Card = forwardRef<HTMLDivElement, CardProps>(({ className, ...props }, ref) => (
+export const Card = React.forwardRef<HTMLDivElement, CardProps>(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn('bg-white dark:bg-gray-900 rounded-xl border border-border shadow-sm', className)}
+    className={cn('rounded-xl border border-border bg-white dark:bg-gray-900 shadow-sm', className)}
     {...props}
   />
 ))
 Card.displayName = 'Card'
 
-export const CardContent = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
+export const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn('p-4', className)} {...props} />
+    <div ref={ref} className={cn('flex flex-col space-y-1.5 p-5', className)} {...props} />
+  )
+)
+CardHeader.displayName = 'CardHeader'
+
+export const CardTitle = React.forwardRef<HTMLHeadingElement, React.HTMLAttributes<HTMLHeadingElement>>(
+  ({ className, ...props }, ref) => (
+    <h3 ref={ref} className={cn('font-semibold leading-none tracking-tight', className)} {...props} />
+  )
+)
+CardTitle.displayName = 'CardTitle'
+
+export const CardDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
+  ({ className, ...props }, ref) => (
+    <p ref={ref} className={cn('text-sm text-muted-foreground', className)} {...props} />
+  )
+)
+CardDescription.displayName = 'CardDescription'
+
+export const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('p-5 pt-0', className)} {...props} />
   )
 )
 CardContent.displayName = 'CardContent'
+
+export const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex items-center p-5 pt-0', className)} {...props} />
+  )
+)
+CardFooter.displayName = 'CardFooter'
+
+export {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+}

--- a/src/content/homepage/pricing.ts
+++ b/src/content/homepage/pricing.ts
@@ -11,16 +11,17 @@ export interface PricingTier {
 }
 
 export const pricing = {
-  headline: 'Transparent packages for growing teams with room for custom enterprise scopes.',
+  headline:
+    'Transparent packages for growing teams with room for custom enterprise scopes.',
   tiers: [
     {
       title: 'Launch Pad',
       price: '$4,000',
       microcopy: 'Ideal for SaaS MVPs',
-      description: 'Deploy a conversion ready MVP in under two weeks.',
+      description: 'Deploy a conversion‑ready MVP in under two weeks.',
       features: [
         'Core landing pages & blog setup',
-        'Responsive design + basic analytics',
+        'Responsive design & basic analytics',
         'Lead capture and onboarding funnel',
         'Launch roadmap session',
       ],

--- a/src/content/homepage/pricing.ts
+++ b/src/content/homepage/pricing.ts
@@ -10,19 +10,24 @@ export interface PricingTier {
   cta: string;
 }
 
-export const pricing = {
+export interface PricingData {
+  headline: string;
+  tiers: PricingTier[];
+}
+
+export const pricing: PricingData = {
   headline:
-    'Transparent packages for growing teams with room for custom enterprise scopes.',
+    'Transparent packages with room to grow. Choose the plan that best aligns with your launch goals and budget.',
   tiers: [
     {
       title: 'Launch Pad',
       price: '$4,000',
       microcopy: 'Ideal for SaaS MVPs',
-      description: 'Deploy a conversion‑ready MVP in under two weeks.',
+      description: 'Spin up a conversion\u2011ready MVP in less than two weeks.',
       features: [
-        'Core landing pages & blog setup',
+        'Core pages & blog setup',
         'Responsive design & basic analytics',
-        'Lead capture and onboarding funnel',
+        'Lead capture funnel',
         'Launch roadmap session',
       ],
       cta: 'Build My Plan',
@@ -32,9 +37,9 @@ export const pricing = {
       price: '$7,500',
       highlight: true,
       microcopy: 'Most popular for funded startups',
-      description: 'Save 40+ hours on funnel setup and automation.',
+      description: 'Save 40+ hours with an automated funnel and CRM.',
       features: [
-        'Multi-page CMS with SEO polish',
+        'Full CMS with SEO polish',
         'CRM & email automations',
         'Analytics dashboards & A/B testing',
         'Ongoing optimization support',
@@ -44,7 +49,7 @@ export const pricing = {
     {
       title: 'Scale Partner',
       price: '$10,000+',
-      microcopy: 'Enterprise or custom scope',
+      microcopy: 'Custom enterprise scope',
       description: 'We architect a scalable system tailored to your ops.',
       features: [
         'Custom integrations & API work',

--- a/src/content/homepage/pricing.ts
+++ b/src/content/homepage/pricing.ts
@@ -1,148 +1,57 @@
-// content/pricing.ts
+// src/content/homepage/pricing.ts
 
-export const pricing = [
-  {
-    category: "Web Development",
-    headline: "From MVP to investor-ready — launch fast, scale smart.",
-    tiers: [
-      {
-        title: "Launch Fast",
-        price: "$1,490",
-        highlight: false,
-        description: "Get live in 7 days with a polished, conversion-ready MVP.",
-        features: [
-          "1-page or MVP site",
-          "Mobile-first responsive design",
-          "Lead capture + contact form",
-          "Core brand styling",
-          "Fast delivery (7 days avg)",
-        ],
-        cta: "Launch My Site",
-      },
-      {
-        title: "Conversion Engine",
-        price: "$3,500",
-        highlight: true,
-        description: "Your site becomes a funnel — designed to scale traffic and leads.",
-        features: [
-          "Multi-page CMS website",
-          "CRM + email integration",
-          "Custom animations + scroll logic",
-          "SEO + speed optimized",
-          "Conversion-first UX copy",
-        ],
-        cta: "Build My Funnel",
-      },
-      {
-        title: "Investor Magnet",
-        price: "$6,000+",
-        highlight: false,
-        description: "A flagship site that turns heads and secures funding.",
-        features: [
-          "6+ pages with premium layout",
-          "Full UI/UX polish + advanced animations",
-          "CMS with custom API hooks",
-          "Interactive components",
-          "Investor-ready presentation layer",
-        ],
-        cta: "Go Enterprise",
-      },
-    ],
-  },
-  {
-    category: "Systems That Scale",
-    headline: "Automation + infrastructure to grow like a $10M company.",
-    tiers: [
-      {
-        title: "Automate & Save",
-        price: "$2,500",
-        highlight: false,
-        description: "Start saving 20+ hours/month with smart automations.",
-        features: [
-          "CRM setup (GoHighLevel, HubSpot, or Notion)",
-          "Email nurture flows",
-          "Lead intake automation",
-          "2 Zapier/Make workflows",
-          "Basic team SOPs",
-        ],
-        cta: "Start Automating",
-      },
-      {
-        title: "Growth Stack",
-        price: "$6,400",
-        highlight: true,
-        description: "Your operating system for revenue, hiring, and scale.",
-        features: [
-          "Sales & marketing CRM buildout",
-          "Funnel tracking dashboards",
-          "Hiring + onboarding systems",
-          "Team Notion workspace + SOPs",
-          "Automation across 4+ departments",
-        ],
-        cta: "Build My Stack",
-      },
-      {
-        title: "Founder's OS",
-        price: "$12,000+",
-        highlight: false,
-        description: "Custom stack, investor-ready architecture, and scale support.",
-        features: [
-          "Custom Retool/Airtable/Make dashboards",
-          "Slack, CRM, Notion + hiring integrations",
-          "Advanced permissioning + roles",
-          "Team training & onboarding materials",
-          "Investor-grade tech ops design",
-        ],
-        cta: "Systemize It All",
-      },
-    ],
-  },
-  {
-    category: "Growth Retainers",
-    headline: "Ongoing optimization to keep your digital engine compounding.",
-    tiers: [
-      {
-        title: "Site Support",
-        price: "$500/mo",
-        highlight: false,
-        description: "Keep your site updated and always sharp.",
-        features: [
-          "Monthly content edits",
-          "CRO tweak (1/month)",
-          "Performance monitoring",
-          "Speed & SEO checkups",
-          "Priority support access",
-        ],
-        cta: "Keep Me Updated",
-      },
-      {
-        title: "Growth Optimization",
-        price: "$1,000/mo",
-        highlight: true,
-        description: "Ongoing CRO, testing, and updates that drive conversion growth.",
-        features: [
-          "Bi-weekly A/B testing",
-          "2+ monthly CRO updates",
-          "Quarterly UX refreshes",
-          "Analytics dashboard setup",
-          "Conversion reporting",
-        ],
-        cta: "Optimize My Growth",
-      },
-      {
-        title: "Revenue Partner",
-        price: "$2,000+/mo",
-        highlight: false,
-        description: "Full partnership model for conversion, funnel, and MRR growth.",
-        features: [
-          "Unlimited site edits",
-          "Weekly strategy sessions",
-          "Performance + ROI dashboards",
-          "Revenue-focused design upgrades",
-          "Quarterly funnel rebuilds",
-        ],
-        cta: "Be My Partner",
-      },
-    ],
-  },
-];
+export interface PricingTier {
+  title: string;
+  price: string;
+  highlight?: boolean;
+  microcopy: string;
+  description: string;
+  features: string[];
+  cta: string;
+}
+
+export const pricing = {
+  headline: 'Transparent packages for growing teams with room for custom enterprise scopes.',
+  tiers: [
+    {
+      title: 'Launch Pad',
+      price: '$4,000',
+      microcopy: 'Ideal for SaaS MVPs',
+      description: 'Deploy a conversion ready MVP in under two weeks.',
+      features: [
+        'Core landing pages & blog setup',
+        'Responsive design + basic analytics',
+        'Lead capture and onboarding funnel',
+        'Launch roadmap session',
+      ],
+      cta: 'Build My Plan',
+    },
+    {
+      title: 'Growth Engine',
+      price: '$7,500',
+      highlight: true,
+      microcopy: 'Most popular for funded startups',
+      description: 'Save 40+ hours on funnel setup and automation.',
+      features: [
+        'Multi-page CMS with SEO polish',
+        'CRM & email automations',
+        'Analytics dashboards & A/B testing',
+        'Ongoing optimization support',
+      ],
+      cta: 'Unlock ROI',
+    },
+    {
+      title: 'Scale Partner',
+      price: '$10,000+',
+      microcopy: 'Enterprise or custom scope',
+      description: 'We architect a scalable system tailored to your ops.',
+      features: [
+        'Custom integrations & API work',
+        'Advanced animations & UX',
+        'Scalable CMS architecture',
+        'Roadmapping with our founder',
+      ],
+      cta: 'Start Partnership',
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- rebuild pricing content with new tiers and microcopy
- redesign pricing section and highlight middle tier
- add custom quote modal for enterprise leads
- update pages to use new PricingSection

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_684a2bc49040832898e06143237111ce