### PR TITLE
Add animated Why Us page

### DIFF
--- a/src/app/why-us/page.tsx
+++ b/src/app/why-us/page.tsx
@@ -1,5 +1,37 @@
 'use client'
 
+import StickyHeader from '@/components/global/Header'
+import FooterSection from '@/components/global/Footer'
+import TruthStack from '@/components/whyus/TruthStack'
+import CTASection from '@/components/whyus/CTASection'
+import { truthSequences } from '@/content/whyus/sequences'
+import { usePathname } from 'next/navigation'
+import { motion, useScroll } from 'framer-motion'
+import { useRef } from 'react'
+
 export default function WhyUsPage() {
-  return null
+  const pathname = usePathname()
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const { scrollYProgress } = useScroll({ target: containerRef })
+
+  return (
+    <section>
+      <StickyHeader />
+      <main
+        key={pathname}
+        ref={containerRef}
+        className="relative w-full overflow-x-hidden bg-white text-black"
+      >
+        <motion.div
+          style={{ scaleX: scrollYProgress }}
+          className="fixed left-0 top-0 h-1 w-full origin-left bg-[var(--color-accent)]"
+        />
+        {truthSequences.map((seq, i) => (
+          <TruthStack key={seq.id} sequence={seq} index={i} />
+        ))}
+        <CTASection />
+      </main>
+      <FooterSection />
+    </section>
+  )
 }

--- a/src/components/whyus/CTASection.tsx
+++ b/src/components/whyus/CTASection.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import Link from 'next/link'
+import { ArrowRight } from 'lucide-react'
+
+export default function CTASection() {
+  return (
+    <section className="bg-[var(--color-bg-dark)] text-[var(--color-text-light)] py-20 px-4 text-center">
+      <div className="mx-auto max-w-2xl space-y-6">
+        <h2 className="text-2xl font-bold">
+          Don’t fall for the hype. Build the system your business actually needs.
+        </h2>
+        <Link
+          href="/contact"
+          className="relative inline-flex items-center justify-center gap-2 rounded-full bg-white px-6 py-3 font-semibold text-black shadow-md transition hover:scale-105"
+        >
+          Book Your Strategy Call <ArrowRight className="h-4 w-4" />
+        </Link>
+        <ul className="mt-4 space-y-1 text-sm text-gray-300">
+          <li>✅ We audit your current site for leaks</li>
+          <li>✅ Show you where you’re leaving money on the table</li>
+          <li>✅ You leave with clarity — whether we work together or not</li>
+        </ul>
+      </div>
+    </section>
+  )
+}

--- a/src/components/whyus/TruthStack.tsx
+++ b/src/components/whyus/TruthStack.tsx
@@ -1,0 +1,67 @@
+'use client'
+
+import { motion, useInView } from 'framer-motion'
+import { useRef } from 'react'
+import type { TruthSequence } from '@/content/whyus/sequences'
+
+interface Props {
+  sequence: TruthSequence
+}
+
+export default function TruthStack({ sequence }: Props) {
+  const ref = useRef<HTMLDivElement | null>(null)
+  const inView = useInView(ref, { once: true, margin: '-20% 0px -20% 0px' })
+
+  const cardVariants = {
+    hidden: { opacity: 0, y: 80 },
+    visible: (i: number) => ({
+      opacity: 1,
+      y: 0,
+      transition: { delay: i * 0.2, duration: 0.6 }
+    })
+  }
+
+  return (
+    <div
+      ref={ref}
+      id={sequence.id}
+      className="relative flex min-h-[80vh] items-center justify-center"
+    >
+      <div className="relative w-full max-w-md px-4 sm:px-0">
+        <motion.div
+          className="card-style pointer-events-none absolute inset-0 z-30 flex flex-col items-center justify-center rounded-xl bg-white p-6 text-center shadow-lg"
+          variants={cardVariants}
+          initial="hidden"
+          animate={inView ? 'visible' : 'hidden'}
+          custom={0}
+        >
+          <p className="text-xl font-semibold text-gray-800">{sequence.claim}</p>
+        </motion.div>
+        <motion.div
+          className="card-style pointer-events-none absolute inset-0 z-20 flex flex-col items-center justify-center rounded-xl bg-gray-800/90 p-6 text-center text-gray-100 backdrop-blur-sm"
+          variants={cardVariants}
+          initial="hidden"
+          animate={inView ? 'visible' : 'hidden'}
+          custom={1}
+        >
+          <p className="text-xl font-semibold">{sequence.truth}</p>
+        </motion.div>
+        <motion.div
+          className="pointer-events-auto relative flex flex-col items-center justify-center rounded-xl bg-gradient-to-br from-pink-500 via-red-500 to-red-600 p-6 text-center text-white shadow-xl"
+          variants={cardVariants}
+          initial="hidden"
+          animate={inView ? 'visible' : 'hidden'}
+          custom={2}
+        >
+          <p className="text-xl font-semibold">{sequence.counter}</p>
+          <p className="mt-2 text-sm text-white/80">
+            Built with the same frameworks used by $50k+ startup sites. No guesswork.
+          </p>
+          <span className="pointer-events-none absolute bottom-2 right-2 text-xs text-white/50">
+            Built by NPR Media
+          </span>
+        </motion.div>
+      </div>
+    </div>
+  )
+}

--- a/src/content/whyus/sequences.ts
+++ b/src/content/whyus/sequences.ts
@@ -1,0 +1,45 @@
+export interface TruthSequence {
+  id: string;
+  claim: string;
+  truth: string;
+  counter: string;
+}
+
+export const truthSequences: TruthSequence[] = [
+  {
+    id: 'ai-sites',
+    claim: 'Launch in minutes!',
+    truth: 'Zero strategy. Zero retention.',
+    counter: 'Custom funnels. Built for buyer logic.',
+  },
+  {
+    id: 'agencies',
+    claim: 'Award-winning creative.',
+    truth: 'Templated. Outsourced. Overbilled.',
+    counter: 'Founder-led systems that scale with you.',
+  },
+  {
+    id: 'cost',
+    claim: '$10/mo websites!',
+    truth: "You're the product. You're locked in.",
+    counter: 'Full code ownership. Built for ROI.',
+  },
+  {
+    id: 'stack',
+    claim: 'No-code magic',
+    truth: 'Rigid. Unscalable. Bloated.',
+    counter: 'Next.js + CMS. Fast, dynamic, future-ready.',
+  },
+  {
+    id: 'control',
+    claim: 'One-click AI hosting',
+    truth: 'Closed platform. No control.',
+    counter: 'You own everything — content, stack, path.',
+  },
+  {
+    id: 'outcomes',
+    claim: 'We design pretty sites.',
+    truth: 'No KPIs. No growth. Just views.',
+    counter: 'Every section engineered to convert.',
+  },
+];


### PR DESCRIPTION
## Summary
- build a Why Us page that shows a scroll progress bar
- create stack animation with Claim/Truth/NPR copy
- include a CTA section

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_685346e114f88328ad6af037729f3f17