### PR TITLE
Add animated TruthStack sequences for Why Us page

### DIFF
--- a/src/app/why-us/page.tsx
+++ b/src/app/why-us/page.tsx
@@ -1,5 +1,52 @@
 'use client'
 
+import StickyHeader from '@/components/global/Header'
+import FooterSection from '@/components/global/Footer'
+import TruthStack from '@/components/whyus/TruthStack'
+import { truthStacks } from '@/content/whyus/truths'
+import { motion, useScroll } from 'framer-motion'
+import Link from 'next/link'
+
 export default function WhyUsPage() {
-  return null
+  const { scrollYProgress } = useScroll()
+
+  return (
+    <section>
+      <StickyHeader />
+      <main className="relative w-full overflow-x-hidden bg-white text-black">
+        <motion.div
+          style={{ scaleX: scrollYProgress }}
+          className="fixed left-0 right-0 top-16 h-1 origin-left bg-pink-500/70"
+        />
+        {truthStacks.map((stack, idx) => (
+          <TruthStack key={idx} index={idx} {...stack} />
+        ))}
+        <CTASection />
+      </main>
+      <FooterSection />
+    </section>
+  )
+}
+
+function CTASection() {
+  return (
+    <section className="bg-gray-50 py-[clamp(5rem,10vw,8rem)] text-center">
+      <div className="mx-auto max-w-2xl space-y-6 px-4">
+        <h2 className="text-[clamp(1.5rem,3vw,2rem)] font-bold">
+          Don&apos;t fall for the hype. Build the system your business actually needs.
+        </h2>
+        <Link
+          href="#booking"
+          className="inline-flex items-center justify-center gap-2 rounded-full bg-[var(--color-accent)] px-[clamp(1.25rem,3vw,1.5rem)] py-[clamp(0.6rem,1.2vw,0.75rem)] font-semibold text-black shadow hover:scale-105 hover:shadow-lg"
+        >
+          Book Your Strategy Call →
+        </Link>
+        <ul className="mx-auto mt-4 max-w-md space-y-1 text-left text-sm text-gray-700">
+          <li>✅ We audit your current site for leaks</li>
+          <li>✅ Show you where you&apos;re leaving money on the table</li>
+          <li>✅ You leave with clarity — whether we work together or not</li>
+        </ul>
+      </div>
+    </section>
+  )
 }

--- a/src/components/whyus/TruthStack.tsx
+++ b/src/components/whyus/TruthStack.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { motion, useScroll, useTransform } from 'framer-motion'
+import { useRef } from 'react'
+import type { TruthStackData } from '@/content/whyus/truths'
+
+interface Props extends TruthStackData {
+  index: number
+}
+
+export default function TruthStack({ desire, disillusion, decision, index }: Props) {
+  const ref = useRef<HTMLDivElement>(null)
+  const { scrollYProgress } = useScroll({
+    target: ref,
+    offset: ['start end', 'end start'],
+  })
+
+  const desireOpacity = useTransform(scrollYProgress, [0, 0.3], [1, 0])
+  const disillusionOpacity = useTransform(scrollYProgress, [0.3, 0.6], [0, 1])
+  const decisionOpacity = useTransform(scrollYProgress, [0.6, 1], [0, 1])
+
+  const desireY = useTransform(scrollYProgress, [0, 0.3], [0, -50])
+  const disillusionY = useTransform(scrollYProgress, [0.3, 0.6], [50, 0])
+  const decisionY = useTransform(scrollYProgress, [0.6, 1], [50, 0])
+
+  return (
+    <section ref={ref} className="relative h-[200vh]">
+      <div className="sticky top-20 flex h-[80vh] items-center justify-center">
+        <motion.div
+          style={{ opacity: desireOpacity, y: desireY, zIndex: 30 - index }}
+          className="absolute flex w-[min(90%,500px)] flex-col items-center rounded-xl bg-white p-6 text-center shadow-lg"
+        >
+          <p className="text-lg font-semibold">{desire}</p>
+        </motion.div>
+        <motion.div
+          style={{ opacity: disillusionOpacity, y: disillusionY, zIndex: 20 - index }}
+          className="absolute flex w-[min(90%,500px)] flex-col items-center rounded-xl bg-gray-800/90 p-6 text-center text-gray-100 backdrop-blur-sm"
+        >
+          <p className="text-lg font-semibold">{disillusion}</p>
+        </motion.div>
+        <motion.div
+          style={{ opacity: decisionOpacity, y: decisionY, zIndex: 10 - index }}
+          className="relative flex w-[min(90%,500px)] flex-col items-center rounded-xl bg-gradient-to-br from-pink-500 to-red-600 p-6 text-center text-white shadow-xl"
+        >
+          <p className="text-lg font-semibold">{decision}</p>
+          <p className="mt-2 text-sm text-white/80">
+            Built with the same frameworks used by $50k+ startup sites. No guesswork.
+          </p>
+          <span className="pointer-events-none absolute bottom-2 right-2 text-xs font-semibold text-white/40">
+            Built by NPR Media
+          </span>
+        </motion.div>
+      </div>
+    </section>
+  )
+}

--- a/src/content/whyus/truths.ts
+++ b/src/content/whyus/truths.ts
@@ -1,0 +1,38 @@
+export interface TruthStackData {
+  desire: string;
+  disillusion: string;
+  decision: string;
+}
+
+export const truthStacks: TruthStackData[] = [
+  {
+    desire: 'Launch in minutes!',
+    disillusion: 'Zero strategy. Zero retention.',
+    decision: 'Custom funnels. Built for buyer logic.'
+  },
+  {
+    desire: 'Award-winning creative.',
+    disillusion: 'Templated. Outsourced. Overbilled.',
+    decision: 'Founder-led systems that scale with you.'
+  },
+  {
+    desire: '$10/mo websites!',
+    disillusion: "You're the product. You're locked in.",
+    decision: 'Full code ownership. Built for ROI.'
+  },
+  {
+    desire: 'No-code magic',
+    disillusion: 'Rigid. Unscalable. Bloated.',
+    decision: 'Next.js + CMS. Fast, dynamic, future-ready.'
+  },
+  {
+    desire: 'One-click AI hosting',
+    disillusion: 'Closed platform. No control.',
+    decision: 'You own everything — content, stack, path.'
+  },
+  {
+    desire: 'We design pretty sites.',
+    disillusion: 'No KPIs. No growth. Just views.',
+    decision: 'Every section engineered to convert.'
+  }
+];


### PR DESCRIPTION
## Summary
- build out new Why Us page with animated stacks
- create TruthStack component powered by framer-motion
- add copy data for all Truth Sequences

## Testing
- `pnpm lint`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_685346e114f88328ad6af037729f3f17