### PR TITLE
Add animated Why Us page

### DIFF
--- a/src/app/why-us/page.tsx
+++ b/src/app/why-us/page.tsx
@@ -1,5 +1,66 @@
 'use client'
 
+import StickyHeader from '@/components/global/Header'
+import FooterSection from '@/components/global/Footer'
+import TruthStack from '@/components/whyus/TruthStack'
+import Testimonial from '@/components/whyus/Testimonial'
+import { sequences, cta } from '@/content/whyUs'
+import { motion, useScroll } from 'framer-motion'
+import { useRef, useEffect } from 'react'
+
 export default function WhyUsPage() {
-  return null
+  const progressRef = useRef<HTMLDivElement>(null)
+  const { scrollYProgress } = useScroll({ target: progressRef })
+
+  useEffect(() => {
+    const unsubscribe = scrollYProgress.on('change', v => {
+      if (progressRef.current) progressRef.current.style.setProperty('--progress', `${v}`)
+      if (v > 0.95) console.log('all stacks viewed')
+    })
+    return () => unsubscribe()
+  }, [scrollYProgress])
+
+  const startTimeRef = useRef<number>(Date.now())
+  useEffect(() => {
+    return () => {
+      const timeSpent = Date.now() - startTimeRef.current
+      console.log('time on why-us', timeSpent)
+    }
+  }, [])
+
+  return (
+    <section>
+      <StickyHeader />
+      <main className="relative w-full overflow-x-hidden bg-white text-black" ref={progressRef}>
+        <motion.div className="fixed top-0 left-0 h-1 w-full bg-pink-600" style={{ scaleX: scrollYProgress }} />
+        {sequences.map((seq, i) => (
+          <>
+            <TruthStack key={i} {...seq} />
+            {i === 3 && <Testimonial />}
+          </>
+        ))}
+        <motion.div
+          className="mx-auto my-20 max-w-xl space-y-4 text-center"
+          initial={{ opacity: 0, y: 40 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+        >
+          <h2 className="text-2xl font-bold">{cta.headline}</h2>
+          <button
+            onClick={() => console.log('cta click')}
+            className="relative inline-block rounded-full bg-gradient-to-r from-pink-500 to-purple-600 px-6 py-3 font-semibold text-white shadow-lg hover:brightness-110"
+          >
+            {cta.button}
+            <span className="absolute inset-0 -z-10 animate-pulse rounded-full bg-gradient-to-r from-pink-600 to-purple-700 opacity-50" />
+          </button>
+          <ul className="mx-auto mt-4 list-none space-y-1 text-sm text-gray-600">
+            {cta.bullets.map((b, i) => (
+              <li key={i}>✅ {b}</li>
+            ))}
+          </ul>
+        </motion.div>
+      </main>
+      <FooterSection />
+    </section>
+  )
 }

--- a/src/components/whyus/Testimonial.tsx
+++ b/src/components/whyus/Testimonial.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+import { motion } from 'framer-motion'
+
+export default function Testimonial() {
+  return (
+    <motion.div
+      className="mx-auto mb-20 max-w-md rounded-xl bg-gray-100 p-6 text-center shadow"
+      initial={{ opacity: 0, y: 40 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+    >
+      <p className="text-lg italic">&ldquo;Our conversions doubled after switching to NPR.&rdquo;</p>
+      <p className="mt-2 text-sm font-semibold">— Alex, SaaS Founder</p>
+    </motion.div>
+  )
+}

--- a/src/components/whyus/TruthStack.tsx
+++ b/src/components/whyus/TruthStack.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { useRef } from 'react'
+import { motion, useScroll, useTransform } from 'framer-motion'
+import { microcopy } from '@/content/whyUs'
+
+interface TruthStackProps {
+  desire: string
+  disillusion: string
+  decision: string
+}
+
+export default function TruthStack({ desire, disillusion, decision }: TruthStackProps) {
+  const ref = useRef<HTMLDivElement>(null)
+  const { scrollYProgress } = useScroll({ target: ref, offset: ['start end', 'end start'] })
+
+  const card2Y = useTransform(scrollYProgress, [0, 0.5], ['100%', '0%'])
+  const card3Y = useTransform(scrollYProgress, [0.5, 1], ['100%', '0%'])
+  const opacity1 = useTransform(scrollYProgress, [0, 0.3], [1, 0])
+
+  return (
+    <div ref={ref} className="relative h-[120vh] flex items-center justify-center">
+      <div className="sticky top-[20vh] h-[60vh] w-full max-w-xl">
+        <motion.div style={{ opacity: opacity1 }} className="absolute inset-0 z-30 grid place-items-center rounded-xl bg-white p-6 shadow-lg">
+          <p className="text-center text-lg font-semibold text-black">{desire}</p>
+        </motion.div>
+        <motion.div style={{ y: card2Y }} className="absolute inset-0 z-20 grid place-items-center rounded-xl bg-gray-900/90 p-6 text-gray-200 backdrop-blur-md">
+          <p className="text-center text-lg font-semibold">{disillusion}</p>
+        </motion.div>
+        <motion.div style={{ y: card3Y }} className="absolute inset-0 z-10 grid place-items-center rounded-xl bg-gradient-to-br from-pink-600 to-purple-700 p-6 text-white shadow-2xl">
+          <p className="text-center text-lg font-semibold">
+            {decision}
+          </p>
+          <p className="mt-2 text-sm text-gray-100 opacity-80">{microcopy}</p>
+          <span className="pointer-events-none absolute bottom-2 right-3 text-xs text-white/60">Built by NPR Media</span>
+        </motion.div>
+      </div>
+    </div>
+  )
+}

--- a/src/content/whyUs.ts
+++ b/src/content/whyUs.ts
@@ -1,0 +1,51 @@
+export interface Sequence {
+  desire: string;
+  disillusion: string;
+  decision: string;
+}
+
+export const sequences: Sequence[] = [
+  {
+    desire: 'Launch in minutes!',
+    disillusion: 'Zero strategy. Zero retention.',
+    decision: 'Custom funnels. Built for buyer logic.',
+  },
+  {
+    desire: 'Award-winning creative.',
+    disillusion: 'Templated. Outsourced. Overbilled.',
+    decision: 'Founder-led systems that scale with you.',
+  },
+  {
+    desire: '$10/mo websites!',
+    disillusion: "You're the product. You're locked in.",
+    decision: 'Full code ownership. Built for ROI.',
+  },
+  {
+    desire: 'No-code magic',
+    disillusion: 'Rigid. Unscalable. Bloated.',
+    decision: 'Next.js + CMS. Fast, dynamic, future-ready.',
+  },
+  {
+    desire: 'One-click AI hosting',
+    disillusion: 'Closed platform. No control.',
+    decision: 'You own everything — content, stack, path.',
+  },
+  {
+    desire: 'We design pretty sites.',
+    disillusion: 'No KPIs. No growth. Just views.',
+    decision: 'Every section engineered to convert.',
+  },
+];
+
+export const microcopy =
+  'Built with the same frameworks used by $50k+ startup sites. No guesswork.';
+
+export const cta = {
+  headline: 'Don\u2019t fall for the hype. Build the system your business actually needs.',
+  button: 'Book Your Strategy Call \u2192',
+  bullets: [
+    'We audit your current site for leaks',
+    'Show you where you\u2019re leaving money on the table',
+    'You leave with clarity — whether we work together or not',
+  ],
+};


### PR DESCRIPTION
## Summary
- implement interactive Why Us page
- add truth stack animation component and testimonial snippet
- provide CMS-like content for the page

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685346e114f88328ad6af037729f3f17