### PR TITLE
Implement new Why Us page

### DIFF
--- a/src/app/why-us/page.tsx
+++ b/src/app/why-us/page.tsx
@@ -1,5 +1,52 @@
-'use client'
+'use client';
+
+import StickyHeader from '@/components/global/Header';
+import FooterSection from '@/components/global/Footer';
+import TruthStack from '@/components/whyus/TruthStack';
+import { sequences, ctaCopy } from '@/content/why-us/sequences';
+import { motion, useScroll, useTransform } from 'framer-motion';
+import { useRef } from 'react';
+import { useWhyUsAnalytics } from '@/lib/hooks/useWhyUsAnalytics';
 
 export default function WhyUsPage() {
-  return null
+  const pageRef = useRef<HTMLDivElement>(null);
+  const ctaRef = useRef<HTMLAnchorElement>(null);
+  const { scrollYProgress } = useScroll({ target: pageRef });
+  const progressWidth = useTransform(scrollYProgress, [0, 1], ['0%', '100%']);
+
+  useWhyUsAnalytics(ctaRef);
+
+  return (
+    <section ref={pageRef} className="bg-white text-black">
+      <StickyHeader />
+      <motion.div
+        className="fixed top-0 left-0 z-40 h-1 bg-pink-600"
+        style={{ width: progressWidth }}
+      />
+      <main className="w-full overflow-x-hidden">
+        {sequences.map((seq) => (
+          <TruthStack key={seq.id} seq={seq} showTestimonial={seq.id === 'outcomes'} />
+        ))}
+        <div className="border-t bg-gray-50 px-4 py-16 text-center">
+          <h2 className="mx-auto max-w-xl text-2xl font-bold">{ctaCopy.headline}</h2>
+          <motion.a
+            href="#book"
+            ref={ctaRef}
+            className="mt-6 inline-block rounded-full bg-pink-600 px-6 py-3 font-semibold text-white shadow-md hover:scale-105"
+            whileHover={{ scale: 1.05 }}
+          >
+            {ctaCopy.button}
+          </motion.a>
+          <ul className="mx-auto mt-6 max-w-md space-y-1 text-sm text-gray-700">
+            {ctaCopy.bullets.map((b) => (
+              <li key={b} className="flex items-start gap-2">
+                <span>✅</span> <span>{b}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </main>
+      <FooterSection />
+    </section>
+  );
 }

--- a/src/components/whyus/TruthStack.tsx
+++ b/src/components/whyus/TruthStack.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { motion, useScroll, useTransform } from 'framer-motion';
+import { useRef } from 'react';
+import { responseMicrocopy, TruthSequence } from '@/content/why-us/sequences';
+
+interface StackProps {
+  seq: TruthSequence;
+  showTestimonial?: boolean;
+}
+
+export default function TruthStack({ seq, showTestimonial }: StackProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const { scrollYProgress } = useScroll({ target: ref, offset: ['start start', 'end start'] });
+
+  const card1X = useTransform(scrollYProgress, [0, 0.33], ['0%', '-120%']);
+  const card2X = useTransform(scrollYProgress, [0, 0.33, 0.66], ['100%', '0%', '-120%']);
+  const card3X = useTransform(scrollYProgress, [0.66, 1], ['100%', '0%']);
+
+  return (
+    <div ref={ref} className="relative h-[200vh]">
+      <div className="sticky top-0 flex h-screen items-center justify-center">
+        <div className="relative h-[80vh] w-full max-w-md">
+          <motion.div
+            style={{ x: card1X }}
+            className="absolute inset-0 z-30 flex flex-col items-center justify-center rounded-xl bg-white p-6 text-center shadow-lg"
+          >
+            <p className="text-lg font-semibold">{seq.claim}</p>
+          </motion.div>
+
+          <motion.div
+            style={{ x: card2X }}
+            className="absolute inset-0 z-20 flex flex-col items-center justify-center rounded-xl bg-gray-800 p-6 text-center text-white shadow-lg"
+          >
+            <p className="text-lg font-semibold">{seq.truth}</p>
+          </motion.div>
+
+          <motion.div
+            style={{ x: card3X }}
+            className="absolute inset-0 z-10 flex flex-col items-center justify-center rounded-xl bg-gradient-to-br from-pink-600 to-purple-600 p-6 text-center text-white shadow-xl"
+          >
+            <p className="text-lg font-semibold">{seq.response}</p>
+            <p className="mt-2 text-sm text-white/80">{responseMicrocopy}</p>
+            <span className="pointer-events-none absolute right-2 bottom-2 text-[10px] opacity-60">
+              Built by NPR Media
+            </span>
+          </motion.div>
+        </div>
+      </div>
+      {showTestimonial && (
+        <div className="absolute bottom-8 left-1/2 z-40 w-full max-w-sm -translate-x-1/2 rounded-md bg-white p-4 text-center shadow-lg">
+          <p className="text-sm italic">&ldquo;Our leads doubled within a month!&rdquo;</p>
+          <p className="text-xs font-semibold text-gray-500">&mdash; Jane, SaaS Founder</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/content/why-us/sequences.ts
+++ b/src/content/why-us/sequences.ts
@@ -1,0 +1,63 @@
+export interface TruthSequence {
+  id: string;
+  claim: string;
+  truth: string;
+  response: string;
+}
+
+export const sequences: TruthSequence[] = [
+  {
+    id: 'ai',
+    claim: 'Launch in minutes!',
+    truth: 'Zero strategy. Zero retention.',
+    response: 'Custom funnels. Built for buyer logic.',
+  },
+  {
+    id: 'agencies',
+    claim: 'Award-winning creative.',
+    truth: 'Templated. Outsourced. Overbilled.',
+    response: 'Founder-led systems that scale with you.',
+  },
+  {
+    id: 'cost',
+    claim: '$10/mo websites!',
+    truth: "You're the product. You're locked in.",
+    response: 'Full code ownership. Built for ROI.',
+  },
+  {
+    id: 'stack',
+    claim: 'No-code magic',
+    truth: 'Rigid. Unscalable. Bloated.',
+    response: 'Next.js + CMS. Fast, dynamic, future-ready.',
+  },
+  {
+    id: 'control',
+    claim: 'One-click AI hosting',
+    truth: 'Closed platform. No control.',
+    response: 'You own everything \u2014 content, stack, path.',
+  },
+  {
+    id: 'outcomes',
+    claim: 'We design pretty sites.',
+    truth: 'No KPIs. No growth. Just views.',
+    response: 'Every section engineered to convert.',
+  },
+];
+
+export const responseMicrocopy =
+  'Built with the same frameworks used by $50k+ startup sites. No guesswork.';
+
+export const testimonial = {
+  quote: '“Our leads doubled within a month!”',
+  author: 'Jane, SaaS Founder',
+};
+
+export const ctaCopy = {
+  headline: 'Don\u2019t fall for the hype. Build the system your business actually needs.',
+  button: 'Book Your Strategy Call \u2192',
+  bullets: [
+    'We audit your current site for leaks',
+    'Show you where you\u2019re leaving money on the table',
+    'You leave with clarity \u2014 whether we work together or not',
+  ],
+};

--- a/src/lib/hooks/useWhyUsAnalytics.ts
+++ b/src/lib/hooks/useWhyUsAnalytics.ts
@@ -1,0 +1,36 @@
+import { useEffect } from 'react';
+
+export function useWhyUsAnalytics(ctaRef: React.RefObject<HTMLAnchorElement | null>) {
+  useEffect(() => {
+    const start = performance.now();
+
+    const log = (event: string, data: Record<string, unknown> = {}) => {
+      console.log(`[WhyUsAnalytics] ${event}`, data);
+    };
+
+    const onScroll = () => {
+      if (window.innerHeight + window.scrollY >= document.body.scrollHeight - 100) {
+        log('Viewed All Stacks', { ms: Math.round(performance.now() - start) });
+        window.removeEventListener('scroll', onScroll);
+      }
+    };
+
+    const onHover = () => log('CTA Hover');
+    const onClick = () => log('CTA Click');
+
+    window.addEventListener('scroll', onScroll);
+    const cta = ctaRef.current;
+    if (cta) {
+      cta.addEventListener('mouseenter', onHover);
+      cta.addEventListener('click', onClick);
+    }
+
+    return () => {
+      window.removeEventListener('scroll', onScroll);
+      if (cta) {
+        cta.removeEventListener('mouseenter', onHover);
+        cta.removeEventListener('click', onClick);
+      }
+    };
+  }, [ctaRef]);
+}


### PR DESCRIPTION
## Summary
- build new "Why Us" page
- add scroll-driven 3-card truth stacks with framer-motion
- wire analytics hook for scroll and CTA events
- provide content and CTA copy

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685346e114f88328ad6af037729f3f17