### PR TITLE
Improve TruthStack animations

### DIFF
--- a/src/app/why-us/page.tsx
+++ b/src/app/why-us/page.tsx
@@ -24,8 +24,8 @@ export default function WhyUsPage() {
         style={{ width: progressWidth }}
       />
       <main className="w-full overflow-x-hidden">
-        {sequences.map((seq) => (
-          <TruthStack key={seq.id} seq={seq} showTestimonial={seq.id === 'outcomes'} />
+        {sequences.map((seq, idx) => (
+          <TruthStack key={seq.id} seq={seq} index={idx} showTestimonial={seq.id === 'outcomes'} />
         ))}
         <div className="border-t bg-gray-50 px-4 py-16 text-center">
           <h2 className="mx-auto max-w-xl text-2xl font-bold">{ctaCopy.headline}</h2>

--- a/src/components/whyus/TruthStack.tsx
+++ b/src/components/whyus/TruthStack.tsx
@@ -6,37 +6,153 @@ import { responseMicrocopy, TruthSequence } from '@/content/why-us/sequences';
 
 interface StackProps {
   seq: TruthSequence;
+  index: number;
   showTestimonial?: boolean;
 }
 
-export default function TruthStack({ seq, showTestimonial }: StackProps) {
+export default function TruthStack({ seq, index, showTestimonial }: StackProps) {
   const ref = useRef<HTMLDivElement>(null);
   const { scrollYProgress } = useScroll({ target: ref, offset: ['start start', 'end start'] });
 
-  const card1X = useTransform(scrollYProgress, [0, 0.33], ['0%', '-120%']);
-  const card2X = useTransform(scrollYProgress, [0, 0.33, 0.66], ['100%', '0%', '-120%']);
-  const card3X = useTransform(scrollYProgress, [0.66, 1], ['100%', '0%']);
+  const variant = index % 6;
+
+  const card1X = useTransform(
+    scrollYProgress,
+    [0, 0.33],
+    [
+      ['0%', '-120%'],
+      ['0%', '120%'],
+      ['0%', '0%'],
+      ['0%', '0%'],
+      ['0%', '-120%'],
+      ['0%', '0%'],
+    ][variant],
+  );
+
+  const card1Y = useTransform(
+    scrollYProgress,
+    [0, 0.33],
+    [
+      ['0%', '0%'],
+      ['0%', '0%'],
+      ['0%', '-120%'],
+      ['0%', '120%'],
+      ['0%', '120%'],
+      ['0%', '0%'],
+    ][variant],
+  );
+
+  const card1Scale = useTransform(
+    scrollYProgress,
+    [0, 0.33],
+    [
+      [1, 1],
+      [1, 1],
+      [1, 1],
+      [1, 1],
+      [1, 1],
+      [1, 0],
+    ][variant],
+  );
+
+  const card2X = useTransform(
+    scrollYProgress,
+    [0, 0.33, 0.66],
+    [
+      ['100%', '0%', '-120%'],
+      ['-100%', '0%', '120%'],
+      ['0%', '0%', '0%'],
+      ['0%', '0%', '0%'],
+      ['120%', '0%', '-120%'],
+      ['0%', '0%', '0%'],
+    ][variant],
+  );
+
+  const card2Y = useTransform(
+    scrollYProgress,
+    [0, 0.33, 0.66],
+    [
+      ['0%', '0%', '0%'],
+      ['0%', '0%', '0%'],
+      ['100%', '0%', '-120%'],
+      ['-100%', '0%', '120%'],
+      ['-120%', '0%', '120%'],
+      ['0%', '0%', '0%'],
+    ][variant],
+  );
+
+  const card2Scale = useTransform(
+    scrollYProgress,
+    [0, 0.33, 0.66],
+    [
+      [1, 1, 1],
+      [1, 1, 1],
+      [1, 1, 1],
+      [1, 1, 1],
+      [1, 1, 1],
+      [0, 1, 0],
+    ][variant],
+  );
+
+  const card3X = useTransform(
+    scrollYProgress,
+    [0.66, 1],
+    [
+      ['100%', '0%'],
+      ['-100%', '0%'],
+      ['0%', '0%'],
+      ['0%', '0%'],
+      ['120%', '0%'],
+      ['0%', '0%'],
+    ][variant],
+  );
+
+  const card3Y = useTransform(
+    scrollYProgress,
+    [0.66, 1],
+    [
+      ['0%', '0%'],
+      ['0%', '0%'],
+      ['100%', '0%'],
+      ['-100%', '0%'],
+      ['-120%', '0%'],
+      ['0%', '0%'],
+    ][variant],
+  );
+
+  const card3Scale = useTransform(
+    scrollYProgress,
+    [0.66, 1],
+    [
+      [1, 1],
+      [1, 1],
+      [1, 1],
+      [1, 1],
+      [1, 1],
+      [0, 1],
+    ][variant],
+  );
 
   return (
-    <div ref={ref} className="relative h-[200vh]">
+    <div ref={ref} className="relative h-[300vh]">
       <div className="sticky top-0 flex h-screen items-center justify-center">
         <div className="relative h-[80vh] w-full max-w-md">
           <motion.div
-            style={{ x: card1X }}
+            style={{ x: card1X, y: card1Y, scale: card1Scale }}
             className="absolute inset-0 z-30 flex flex-col items-center justify-center rounded-xl bg-white p-6 text-center shadow-lg"
           >
             <p className="text-lg font-semibold">{seq.claim}</p>
           </motion.div>
 
           <motion.div
-            style={{ x: card2X }}
+            style={{ x: card2X, y: card2Y, scale: card2Scale }}
             className="absolute inset-0 z-20 flex flex-col items-center justify-center rounded-xl bg-gray-800 p-6 text-center text-white shadow-lg"
           >
             <p className="text-lg font-semibold">{seq.truth}</p>
           </motion.div>
 
           <motion.div
-            style={{ x: card3X }}
+            style={{ x: card3X, y: card3Y, scale: card3Scale }}
             className="absolute inset-0 z-10 flex flex-col items-center justify-center rounded-xl bg-gradient-to-br from-pink-600 to-purple-600 p-6 text-center text-white shadow-xl"
           >
             <p className="text-lg font-semibold">{seq.response}</p>


### PR DESCRIPTION
## Summary
- vary animations for each TruthStack instance
- allow passing index to TruthStack
- increase height so third card fully animates

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68534cf037f48328ab15af9f2e1109d8