### PR TITLE
Fix why-us card visibility and add varied animations

### DIFF
--- a/src/app/why-us/page.tsx
+++ b/src/app/why-us/page.tsx
@@ -24,8 +24,13 @@ export default function WhyUsPage() {
         style={{ width: progressWidth }}
       />
       <main className="w-full overflow-x-hidden">
-        {sequences.map((seq) => (
-          <TruthStack key={seq.id} seq={seq} showTestimonial={seq.id === 'outcomes'} />
+        {sequences.map((seq, i) => (
+          <TruthStack
+            key={seq.id}
+            seq={seq}
+            variant={i}
+            showTestimonial={seq.id === 'outcomes'}
+          />
         ))}
         <div className="border-t bg-gray-50 px-4 py-16 text-center">
           <h2 className="mx-auto max-w-xl text-2xl font-bold">{ctaCopy.headline}</h2>

--- a/src/components/whyus/TruthStack.tsx
+++ b/src/components/whyus/TruthStack.tsx
@@ -7,36 +7,100 @@ import { responseMicrocopy, TruthSequence } from '@/content/why-us/sequences';
 interface StackProps {
   seq: TruthSequence;
   showTestimonial?: boolean;
+  variant?: number;
 }
 
-export default function TruthStack({ seq, showTestimonial }: StackProps) {
+export default function TruthStack({ seq, showTestimonial, variant = 0 }: StackProps) {
   const ref = useRef<HTMLDivElement>(null);
   const { scrollYProgress } = useScroll({ target: ref, offset: ['start start', 'end start'] });
 
-  const card1X = useTransform(scrollYProgress, [0, 0.33], ['0%', '-120%']);
-  const card2X = useTransform(scrollYProgress, [0, 0.33, 0.66], ['100%', '0%', '-120%']);
-  const card3X = useTransform(scrollYProgress, [0.66, 1], ['100%', '0%']);
+  const card1Style: Record<string, unknown> = {};
+  const card2Style: Record<string, unknown> = {};
+  const card3Style: Record<string, unknown> = {};
+
+  const xLeft1 = useTransform(scrollYProgress, [0, 0.33], ['0%', '-120%']);
+  const xLeft2 = useTransform(scrollYProgress, [0, 0.33, 0.66], ['100%', '0%', '-120%']);
+  const xLeft3 = useTransform(scrollYProgress, [0.66, 1], ['100%', '0%']);
+
+  const xRight1 = useTransform(scrollYProgress, [0, 0.33], ['0%', '120%']);
+  const xRight2 = useTransform(scrollYProgress, [0, 0.33, 0.66], ['-100%', '0%', '120%']);
+  const xRight3 = useTransform(scrollYProgress, [0.66, 1], ['-100%', '0%']);
+
+  const yUp1 = useTransform(scrollYProgress, [0, 0.33], ['0%', '-120%']);
+  const yUp2 = useTransform(scrollYProgress, [0, 0.33, 0.66], ['100%', '0%', '-120%']);
+  const yUp3 = useTransform(scrollYProgress, [0.66, 1], ['100%', '0%']);
+
+  const yDown1 = useTransform(scrollYProgress, [0, 0.33], ['0%', '120%']);
+  const yDown2 = useTransform(scrollYProgress, [0, 0.33, 0.66], ['-100%', '0%', '120%']);
+  const yDown3 = useTransform(scrollYProgress, [0.66, 1], ['-100%', '0%']);
+
+  const scale1 = useTransform(scrollYProgress, [0, 0.33], [1, 0.5]);
+  const scale2 = useTransform(scrollYProgress, [0, 0.33, 0.66], [0.5, 1, 0.5]);
+  const scale3 = useTransform(scrollYProgress, [0.66, 1], [0.5, 1]);
+
+  const opacity1 = useTransform(scrollYProgress, [0, 0.33], [1, 0]);
+  const opacity2 = useTransform(scrollYProgress, [0, 0.33, 0.66], [0, 1, 0]);
+  const opacity3 = useTransform(scrollYProgress, [0.66, 1], [0, 1]);
+
+  const rotate1 = useTransform(scrollYProgress, [0, 0.33], ['0deg', '180deg']);
+  const rotate2 = useTransform(scrollYProgress, [0, 0.33, 0.66], ['-180deg', '0deg', '180deg']);
+  const rotate3 = useTransform(scrollYProgress, [0.66, 1], ['-180deg', '0deg']);
+
+  switch (variant % 6) {
+    case 1:
+      card1Style.x = xRight1;
+      card2Style.x = xRight2;
+      card3Style.x = xRight3;
+      break;
+    case 2:
+      card1Style.y = yUp1;
+      card2Style.y = yUp2;
+      card3Style.y = yUp3;
+      break;
+    case 3:
+      card1Style.y = yDown1;
+      card2Style.y = yDown2;
+      card3Style.y = yDown3;
+      break;
+    case 4:
+      card1Style.scale = scale1;
+      card1Style.opacity = opacity1;
+      card2Style.scale = scale2;
+      card2Style.opacity = opacity2;
+      card3Style.scale = scale3;
+      card3Style.opacity = opacity3;
+      break;
+    case 5:
+      card1Style.rotate = rotate1;
+      card2Style.rotate = rotate2;
+      card3Style.rotate = rotate3;
+      break;
+    default:
+      card1Style.x = xLeft1;
+      card2Style.x = xLeft2;
+      card3Style.x = xLeft3;
+  }
 
   return (
-    <div ref={ref} className="relative h-[200vh]">
+    <div ref={ref} className="relative h-[300vh]">
       <div className="sticky top-0 flex h-screen items-center justify-center">
         <div className="relative h-[80vh] w-full max-w-md">
           <motion.div
-            style={{ x: card1X }}
+            style={card1Style}
             className="absolute inset-0 z-30 flex flex-col items-center justify-center rounded-xl bg-white p-6 text-center shadow-lg"
           >
             <p className="text-lg font-semibold">{seq.claim}</p>
           </motion.div>
 
           <motion.div
-            style={{ x: card2X }}
+            style={card2Style}
             className="absolute inset-0 z-20 flex flex-col items-center justify-center rounded-xl bg-gray-800 p-6 text-center text-white shadow-lg"
           >
             <p className="text-lg font-semibold">{seq.truth}</p>
           </motion.div>
 
           <motion.div
-            style={{ x: card3X }}
+            style={card3Style}
             className="absolute inset-0 z-10 flex flex-col items-center justify-center rounded-xl bg-gradient-to-br from-pink-600 to-purple-600 p-6 text-center text-white shadow-xl"
           >
             <p className="text-lg font-semibold">{seq.response}</p>


### PR DESCRIPTION
## Summary
- ensure entire truth stack scrolls into view
- support alternate animation directions
- show testimonial section once at the bottom

## Testing
- `pnpm lint`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68534cf037f48328ab15af9f2e1109d8