### PR TITLE
Fix third card visibility and vary animations

### DIFF
--- a/src/components/whyus/TruthStack.tsx
+++ b/src/components/whyus/TruthStack.tsx
@@ -13,30 +13,58 @@ export default function TruthStack({ seq, showTestimonial }: StackProps) {
   const ref = useRef<HTMLDivElement>(null);
   const { scrollYProgress } = useScroll({ target: ref, offset: ['start start', 'end start'] });
 
-  const card1X = useTransform(scrollYProgress, [0, 0.33], ['0%', '-120%']);
-  const card2X = useTransform(scrollYProgress, [0, 0.33, 0.66], ['100%', '0%', '-120%']);
-  const card3X = useTransform(scrollYProgress, [0.66, 1], ['100%', '0%']);
+  const variant = seq.variant || 'left';
+
+  const transforms = {
+    left: {
+      card1: { x: useTransform(scrollYProgress, [0, 0.33], ['0%', '-120%']) },
+      card2: { x: useTransform(scrollYProgress, [0, 0.33, 0.66], ['100%', '0%', '-120%']) },
+      card3: { x: useTransform(scrollYProgress, [0.66, 1], ['100%', '0%']) },
+    },
+    right: {
+      card1: { x: useTransform(scrollYProgress, [0, 0.33], ['0%', '120%']) },
+      card2: { x: useTransform(scrollYProgress, [0, 0.33, 0.66], ['-100%', '0%', '120%']) },
+      card3: { x: useTransform(scrollYProgress, [0.66, 1], ['-100%', '0%']) },
+    },
+    up: {
+      card1: { y: useTransform(scrollYProgress, [0, 0.33], ['0%', '-120%']) },
+      card2: { y: useTransform(scrollYProgress, [0, 0.33, 0.66], ['100%', '0%', '-120%']) },
+      card3: { y: useTransform(scrollYProgress, [0.66, 1], ['100%', '0%']) },
+    },
+    down: {
+      card1: { y: useTransform(scrollYProgress, [0, 0.33], ['0%', '120%']) },
+      card2: { y: useTransform(scrollYProgress, [0, 0.33, 0.66], ['-100%', '0%', '120%']) },
+      card3: { y: useTransform(scrollYProgress, [0.66, 1], ['-100%', '0%']) },
+    },
+    zoom: {
+      card1: { scale: useTransform(scrollYProgress, [0, 0.33], [1, 0.5]) },
+      card2: { scale: useTransform(scrollYProgress, [0, 0.33, 0.66], [0.5, 1, 0.5]) },
+      card3: { scale: useTransform(scrollYProgress, [0.66, 1], [0.5, 1]) },
+    },
+  } as const;
+
+  const { card1, card2, card3 } = transforms[variant];
 
   return (
-    <div ref={ref} className="relative h-[200vh]">
-      <div className="sticky top-0 flex h-screen items-center justify-center">
-        <div className="relative h-[80vh] w-full max-w-md">
+    <div ref={ref} className="relative h-[250vh]">
+      <div className="sticky top-[var(--header-height)] flex h-[calc(100vh-var(--header-height))] items-center justify-center">
+        <div className="relative h-full w-full max-w-md">
           <motion.div
-            style={{ x: card1X }}
+            style={card1}
             className="absolute inset-0 z-30 flex flex-col items-center justify-center rounded-xl bg-white p-6 text-center shadow-lg"
           >
             <p className="text-lg font-semibold">{seq.claim}</p>
           </motion.div>
 
           <motion.div
-            style={{ x: card2X }}
+            style={card2}
             className="absolute inset-0 z-20 flex flex-col items-center justify-center rounded-xl bg-gray-800 p-6 text-center text-white shadow-lg"
           >
             <p className="text-lg font-semibold">{seq.truth}</p>
           </motion.div>
 
           <motion.div
-            style={{ x: card3X }}
+            style={card3}
             className="absolute inset-0 z-10 flex flex-col items-center justify-center rounded-xl bg-gradient-to-br from-pink-600 to-purple-600 p-6 text-center text-white shadow-xl"
           >
             <p className="text-lg font-semibold">{seq.response}</p>

--- a/src/content/why-us/sequences.ts
+++ b/src/content/why-us/sequences.ts
@@ -3,6 +3,7 @@ export interface TruthSequence {
   claim: string;
   truth: string;
   response: string;
+  variant?: 'left' | 'right' | 'up' | 'down' | 'zoom';
 }
 
 export const sequences: TruthSequence[] = [
@@ -11,36 +12,42 @@ export const sequences: TruthSequence[] = [
     claim: 'Launch in minutes!',
     truth: 'Zero strategy. Zero retention.',
     response: 'Custom funnels. Built for buyer logic.',
+    variant: 'left',
   },
   {
     id: 'agencies',
     claim: 'Award-winning creative.',
     truth: 'Templated. Outsourced. Overbilled.',
     response: 'Founder-led systems that scale with you.',
+    variant: 'right',
   },
   {
     id: 'cost',
     claim: '$10/mo websites!',
     truth: "You're the product. You're locked in.",
     response: 'Full code ownership. Built for ROI.',
+    variant: 'up',
   },
   {
     id: 'stack',
     claim: 'No-code magic',
     truth: 'Rigid. Unscalable. Bloated.',
     response: 'Next.js + CMS. Fast, dynamic, future-ready.',
+    variant: 'down',
   },
   {
     id: 'control',
     claim: 'One-click AI hosting',
     truth: 'Closed platform. No control.',
     response: 'You own everything \u2014 content, stack, path.',
+    variant: 'zoom',
   },
   {
     id: 'outcomes',
     claim: 'We design pretty sites.',
     truth: 'No KPIs. No growth. Just views.',
     response: 'Every section engineered to convert.',
+    variant: 'left',
   },
 ];
 


### PR DESCRIPTION
## Summary
- ensure third card stacks appear below the header
- vary the animation direction on each stack

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68534cf037f48328ab15af9f2e1109d8