### PR TITLE
Fix last card cutoff

### DIFF
--- a/src/app/why-us/page.tsx
+++ b/src/app/why-us/page.tsx
@@ -3,7 +3,9 @@
 import StickyHeader from '@/components/global/Header';
 import FooterSection from '@/components/global/Footer';
 import TruthStack from '@/components/whyus/TruthStack';
+import HeroSection from '@/components/homepage/Hero';
 import { sequences, ctaCopy } from '@/content/why-us/sequences';
+import { heroWhyUs } from '@/content/why-us/hero';
 import { motion, useScroll, useTransform } from 'framer-motion';
 import { useRef } from 'react';
 import { useWhyUsAnalytics } from '@/lib/hooks/useWhyUsAnalytics';
@@ -24,6 +26,7 @@ export default function WhyUsPage() {
         style={{ width: progressWidth }}
       />
       <main className="w-full overflow-x-hidden">
+        <HeroSection {...heroWhyUs} />
         {sequences.map((seq) => (
           <TruthStack key={seq.id} seq={seq} showTestimonial={seq.id === 'outcomes'} />
         ))}

--- a/src/app/why-us/page.tsx
+++ b/src/app/why-us/page.tsx
@@ -7,7 +7,7 @@ import HeroSection from '@/components/homepage/Hero';
 import { sequences, ctaCopy } from '@/content/why-us/sequences';
 import { heroWhyUs } from '@/content/why-us/hero';
 import { motion, useScroll, useTransform } from 'framer-motion';
-import { useRef } from 'react';
+import { Suspense, useRef } from 'react';
 import { useWhyUsAnalytics } from '@/lib/hooks/useWhyUsAnalytics';
 
 export default function WhyUsPage() {
@@ -26,7 +26,9 @@ export default function WhyUsPage() {
         style={{ width: progressWidth }}
       />
       <main className="w-full overflow-x-hidden">
-        <HeroSection {...heroWhyUs} />
+        <Suspense>
+          <HeroSection {...heroWhyUs} />
+        </Suspense>
         {sequences.map((seq) => (
           <TruthStack key={seq.id} seq={seq} showTestimonial={seq.id === 'outcomes'} />
         ))}

--- a/src/components/whyus/TruthStack.tsx
+++ b/src/components/whyus/TruthStack.tsx
@@ -11,14 +11,19 @@ interface StackProps {
 
 export default function TruthStack({ seq, showTestimonial }: StackProps) {
   const ref = useRef<HTMLDivElement>(null);
-  const { scrollYProgress } = useScroll({ target: ref, offset: ['start start', 'end start'] });
+  // Start the scroll progress when the stack enters the viewport from the bottom
+  // and finish when its center aligns with the screen center so the final card
+  // is perfectly positioned at that point.
+  const { scrollYProgress } = useScroll({
+    target: ref,
+    offset: ['start end', 'center center'],
+  });
 
-  // Stretch the scroll ranges so the cards slide further while remaining in
-  // view. The final card finishes animating around 80% progress so it's fully
-  // visible when the stack is centered on screen.
-  const card1X = useTransform(scrollYProgress, [0, 0.2], ['0%', '-120%']);
-  const card2X = useTransform(scrollYProgress, [0, 0.2, 0.4], ['100%', '0%', '-120%']);
-  const card3X = useTransform(scrollYProgress, [0.4, 0.8], ['100%', '0%']);
+  // Animate each card sequentially so the third card finishes sliding when the
+  // stack reaches the center of the viewport.
+  const card1X = useTransform(scrollYProgress, [0, 0.33], ['0%', '-120%']);
+  const card2X = useTransform(scrollYProgress, [0, 0.33, 0.66], ['100%', '0%', '-120%']);
+  const card3X = useTransform(scrollYProgress, [0.66, 1], ['100%', '0%']);
 
   return (
     <div ref={ref} className="relative h-[300vh]">

--- a/src/components/whyus/TruthStack.tsx
+++ b/src/components/whyus/TruthStack.tsx
@@ -21,15 +21,15 @@ export default function TruthStack({ seq, showTestimonial }: StackProps) {
 
   // Animate each card sequentially so the third card finishes sliding when the
   // stack reaches the center of the viewport.
-  const card1X = useTransform(scrollYProgress, [0, 0.33], ['0%', '-120%']);
+  const card1X = useTransform(scrollYProgress, [0, 0.33], ['0%', '-100%']);
   // Card two should stop moving once centered so visitors can read it
   const card2X = useTransform(scrollYProgress, [0, 0.33, 0.66], ['100%', '0%', '0%']);
   const card3X = useTransform(scrollYProgress, [0.66, 1], ['100%', '0%']);
 
   return (
-    <div ref={ref} className="relative h-[300vh]">
+    <div ref={ref} className="relative h-[220vh]">
       <div className="sticky top-0 flex h-screen items-center justify-center">
-        <div className="relative h-[80vh] w-full max-w-md">
+        <div className="relative h-[65vh] w-full max-w-sm">
           <motion.div
             style={{ x: card1X }}
             className="absolute inset-0 z-30 flex flex-col items-center justify-center rounded-xl bg-white p-6 text-center shadow-lg"

--- a/src/components/whyus/TruthStack.tsx
+++ b/src/components/whyus/TruthStack.tsx
@@ -13,14 +13,15 @@ export default function TruthStack({ seq, showTestimonial }: StackProps) {
   const ref = useRef<HTMLDivElement>(null);
   const { scrollYProgress } = useScroll({ target: ref, offset: ['start start', 'end start'] });
 
-  // Compress the timing so the final card settles while the stack's center
-  // aligns with the middle of the viewport.
-  const card1X = useTransform(scrollYProgress, [0, 0.12], ['0%', '-120%']);
-  const card2X = useTransform(scrollYProgress, [0, 0.12, 0.24], ['100%', '0%', '-120%']);
-  const card3X = useTransform(scrollYProgress, [0.24, 0.29], ['100%', '0%']);
+  // Stretch the scroll ranges so the cards slide further while remaining in
+  // view. The final card finishes animating around 80% progress so it's fully
+  // visible when the stack is centered on screen.
+  const card1X = useTransform(scrollYProgress, [0, 0.2], ['0%', '-120%']);
+  const card2X = useTransform(scrollYProgress, [0, 0.2, 0.4], ['100%', '0%', '-120%']);
+  const card3X = useTransform(scrollYProgress, [0.4, 0.8], ['100%', '0%']);
 
   return (
-    <div ref={ref} className="relative h-[240vh]">
+    <div ref={ref} className="relative h-[300vh]">
       <div className="sticky top-0 flex h-screen items-center justify-center">
         <div className="relative h-[80vh] w-full max-w-md">
           <motion.div

--- a/src/components/whyus/TruthStack.tsx
+++ b/src/components/whyus/TruthStack.tsx
@@ -22,7 +22,8 @@ export default function TruthStack({ seq, showTestimonial }: StackProps) {
   // Animate each card sequentially so the third card finishes sliding when the
   // stack reaches the center of the viewport.
   const card1X = useTransform(scrollYProgress, [0, 0.33], ['0%', '-120%']);
-  const card2X = useTransform(scrollYProgress, [0, 0.33, 0.66], ['100%', '0%', '-120%']);
+  // Card two should stop moving once centered so visitors can read it
+  const card2X = useTransform(scrollYProgress, [0, 0.33, 0.66], ['100%', '0%', '0%']);
   const card3X = useTransform(scrollYProgress, [0.66, 1], ['100%', '0%']);
 
   return (

--- a/src/components/whyus/TruthStack.tsx
+++ b/src/components/whyus/TruthStack.tsx
@@ -15,12 +15,12 @@ export default function TruthStack({ seq, showTestimonial }: StackProps) {
 
   const card1X = useTransform(scrollYProgress, [0, 0.33], ['0%', '-120%']);
   const card2X = useTransform(scrollYProgress, [0, 0.33, 0.66], ['100%', '0%', '-120%']);
-  // Finish the third card animation slightly earlier so the card is
-  // completely visible while centered on screen
-  const card3X = useTransform(scrollYProgress, [0.66, 0.8], ['100%', '0%']);
+  // Finish the third card animation earlier so the card is fully visible
+  // once its center aligns with the center of the viewport
+  const card3X = useTransform(scrollYProgress, [0.66, 0.75], ['100%', '0%']);
 
   return (
-    <div ref={ref} className="relative h-[220vh]">
+    <div ref={ref} className="relative h-[240vh]">
       <div className="sticky top-0 flex h-screen items-center justify-center">
         <div className="relative h-[80vh] w-full max-w-md">
           <motion.div

--- a/src/components/whyus/TruthStack.tsx
+++ b/src/components/whyus/TruthStack.tsx
@@ -14,10 +14,12 @@ export default function TruthStack({ seq, showTestimonial }: StackProps) {
   const { scrollYProgress } = useScroll({ target: ref, offset: ['start start', 'end start'] });
 
   const card1X = useTransform(scrollYProgress, [0, 0.33], ['0%', '-120%']);
-  const card2X = useTransform(scrollYProgress, [0, 0.33, 0.66], ['100%', '0%', '-120%']);
-  // Finish the third card animation earlier so the card is fully visible
-  // once its center aligns with the center of the viewport
-  const card3X = useTransform(scrollYProgress, [0.66, 0.75], ['100%', '0%']);
+  // Move the second card offscreen a bit sooner so the last card animation can
+  // complete while still centered in the viewport.
+  const card2X = useTransform(scrollYProgress, [0, 0.33, 0.52], ['100%', '0%', '-120%']);
+  // Finish the third card animation by the time the stack's center reaches the
+  // middle of the screen so users can fully read the text.
+  const card3X = useTransform(scrollYProgress, [0.52, 0.58], ['100%', '0%']);
 
   return (
     <div ref={ref} className="relative h-[240vh]">

--- a/src/components/whyus/TruthStack.tsx
+++ b/src/components/whyus/TruthStack.tsx
@@ -15,7 +15,9 @@ export default function TruthStack({ seq, showTestimonial }: StackProps) {
 
   const card1X = useTransform(scrollYProgress, [0, 0.33], ['0%', '-120%']);
   const card2X = useTransform(scrollYProgress, [0, 0.33, 0.66], ['100%', '0%', '-120%']);
-  const card3X = useTransform(scrollYProgress, [0.66, 1], ['100%', '0%']);
+  // Finish the third card animation slightly earlier so the card is
+  // completely visible while centered on screen
+  const card3X = useTransform(scrollYProgress, [0.66, 0.8], ['100%', '0%']);
 
   return (
     <div ref={ref} className="relative h-[220vh]">

--- a/src/components/whyus/TruthStack.tsx
+++ b/src/components/whyus/TruthStack.tsx
@@ -11,20 +11,19 @@ interface StackProps {
 
 export default function TruthStack({ seq, showTestimonial }: StackProps) {
   const ref = useRef<HTMLDivElement>(null);
-  // Start the scroll progress when the stack enters the viewport from the bottom
-  // and finish when its center aligns with the screen center so the final card
-  // is perfectly positioned at that point.
+  // Start animating once the stack's top hits the bottom of the viewport and
+  // finish when the card row first aligns with the viewport center. The row is
+  // centered at that moment because the sticky container pins it there.
   const { scrollYProgress } = useScroll({
     target: ref,
-    offset: ['start end', 'center center'],
+    offset: ['start end', 'start start'],
   });
 
-  // Animate each card sequentially so the third card finishes sliding when the
-  // stack reaches the center of the viewport.
-  const card1X = useTransform(scrollYProgress, [0, 0.33], ['0%', '-100%']);
-  // Card two should stop moving once centered so visitors can read it
-  const card2X = useTransform(scrollYProgress, [0, 0.33, 0.66], ['100%', '0%', '0%']);
-  const card3X = useTransform(scrollYProgress, [0.66, 1], ['100%', '0%']);
+  // Animate each card sequentially so the last card completes its slide as soon
+  // as the row is centered on screen.
+  const card1X = useTransform(scrollYProgress, [0, 0.25], ['0%', '-100%']);
+  const card2X = useTransform(scrollYProgress, [0, 0.25, 0.5, 0.625], ['100%', '0%', '0%', '-100%']);
+  const card3X = useTransform(scrollYProgress, [0.5, 0.625], ['100%', '0%']);
 
   return (
     <div ref={ref} className="relative h-[220vh]">

--- a/src/components/whyus/TruthStack.tsx
+++ b/src/components/whyus/TruthStack.tsx
@@ -13,13 +13,11 @@ export default function TruthStack({ seq, showTestimonial }: StackProps) {
   const ref = useRef<HTMLDivElement>(null);
   const { scrollYProgress } = useScroll({ target: ref, offset: ['start start', 'end start'] });
 
-  const card1X = useTransform(scrollYProgress, [0, 0.33], ['0%', '-120%']);
-  // Move the second card offscreen a bit sooner so the last card animation can
-  // complete while still centered in the viewport.
-  const card2X = useTransform(scrollYProgress, [0, 0.33, 0.52], ['100%', '0%', '-120%']);
-  // Finish the third card animation by the time the stack's center reaches the
-  // middle of the screen so users can fully read the text.
-  const card3X = useTransform(scrollYProgress, [0.52, 0.58], ['100%', '0%']);
+  // Compress the timing so the final card settles while the stack's center
+  // aligns with the middle of the viewport.
+  const card1X = useTransform(scrollYProgress, [0, 0.12], ['0%', '-120%']);
+  const card2X = useTransform(scrollYProgress, [0, 0.12, 0.24], ['100%', '0%', '-120%']);
+  const card3X = useTransform(scrollYProgress, [0.24, 0.29], ['100%', '0%']);
 
   return (
     <div ref={ref} className="relative h-[240vh]">

--- a/src/components/whyus/TruthStack.tsx
+++ b/src/components/whyus/TruthStack.tsx
@@ -18,7 +18,7 @@ export default function TruthStack({ seq, showTestimonial }: StackProps) {
   const card3X = useTransform(scrollYProgress, [0.66, 1], ['100%', '0%']);
 
   return (
-    <div ref={ref} className="relative h-[200vh]">
+    <div ref={ref} className="relative h-[220vh]">
       <div className="sticky top-0 flex h-screen items-center justify-center">
         <div className="relative h-[80vh] w-full max-w-md">
           <motion.div

--- a/src/content/why-us/hero.ts
+++ b/src/content/why-us/hero.ts
@@ -1,0 +1,8 @@
+import { HeroProps } from '@/content/homepage/hero';
+
+export const heroWhyUs: HeroProps = {
+  headline: 'Why NPR Media?',
+  subheadline: 'See how real experts outperform AI and templates.',
+  ctaText: 'Get your free audit',
+  ctaLink: '/#book',
+};


### PR DESCRIPTION
## Summary
- tweak `TruthStack` scroll container to make last card fully visible

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68534fec17f883288f66daa9badeb4fe