### PR TITLE
Add why-npr page

### DIFF
--- a/src/app/why-npr/page.tsx
+++ b/src/app/why-npr/page.tsx
@@ -1,0 +1,19 @@
+import StickyHeader from '@/components/global/Header';
+import FooterSection from '@/components/global/Footer';
+import VsAiSection from '@/components/comparison/VsAiSection';
+import VsAgencySection from '@/components/comparison/VsAgencySection';
+import FinalStickyCTA from '@/components/comparison/FinalStickyCTA';
+
+export default function WhyNprPage() {
+  return (
+    <section>
+      <StickyHeader />
+      <main className="relative w-full overflow-x-hidden bg-white text-black">
+        <VsAiSection />
+        <VsAgencySection />
+      </main>
+      <FooterSection />
+      <FinalStickyCTA />
+    </section>
+  );
+}

--- a/src/components/comparison/FinalStickyCTA.tsx
+++ b/src/components/comparison/FinalStickyCTA.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+
+export default function FinalStickyCTA() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => {
+      setVisible(window.scrollY > window.innerHeight / 2);
+    };
+    window.addEventListener('scroll', onScroll);
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  if (!visible) return null;
+
+  return (
+    <div className="fixed bottom-4 left-1/2 z-50 -translate-x-1/2 rounded-full bg-[var(--color-accent)] px-6 py-3 text-sm font-semibold text-white shadow-lg">
+      <Link href="/contact">Schedule Your Strategy Sprint</Link>
+    </div>
+  );
+}

--- a/src/components/comparison/VsAgencySection.tsx
+++ b/src/components/comparison/VsAgencySection.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import Link from 'next/link';
+
+export default function VsAgencySection() {
+  return (
+    <section className="bg-[var(--color-bg-dark)] py-[clamp(5rem,10vw,8rem)] text-[var(--color-text-light)]">
+      <div className="container mx-auto space-y-10 px-4">
+        <h2 className="text-center text-[clamp(1.75rem,3.5vw,2.5rem)] font-bold tracking-tight">
+          NPR Media vs Other Firms
+        </h2>
+        <p className="text-center text-[clamp(0.9rem,1.6vw,1.125rem)]">
+          Most agencies sell time. We sell outcomes.
+        </p>
+
+        <div className="overflow-hidden rounded-xl border border-[var(--color-gray-700)]">
+          <motion.div drag="y" dragConstraints={{ top: -220, bottom: 0 }} className="space-y-8 p-6">
+            <div className="grid gap-4 text-sm md:grid-cols-3">
+              <div className="font-semibold">Others</div>
+              <div className="font-semibold">NPR</div>
+              <div className="font-semibold">Your Gain</div>
+              <div>Opaque pricing</div>
+              <div>Transparent packages</div>
+              <div>Know costs upfront</div>
+              <div>Junior talent</div>
+              <div>Senior specialists</div>
+              <div>Expert execution</div>
+              <div>Pretty mockups only</div>
+              <div>Strategic copy + full stack</div>
+              <div>Messaging that converts</div>
+              <div>Missed deadlines</div>
+              <div>Reliable sprints</div>
+              <div>Launch on time</div>
+            </div>
+
+            <div className="pt-6 text-sm">
+              <div className="mb-2 font-semibold">Agency Bloat</div>
+              <ul className="list-disc space-y-1 pl-5">
+                <li>4-week discovery calls</li>
+                <li>$2k for wireframes</li>
+                <li>Slow handoffs</li>
+                <li>No CRO or testing</li>
+              </ul>
+            </div>
+
+            <div className="pt-6 text-sm">
+              <div className="mb-2 font-semibold">NPR Delivery Stack</div>
+              <ul className="list-disc space-y-1 pl-5">
+                <li>Production-grade homepage</li>
+                <li>9-section CMS site</li>
+                <li>SOP-aligned builds</li>
+                <li>Real-time revisions</li>
+                <li>Vercel-level hosting</li>
+              </ul>
+            </div>
+
+            <div className="pt-6 text-center text-sm italic">
+              “94% of our clients switch from other firms—and never go back.”
+            </div>
+          </motion.div>
+        </div>
+
+        <div className="pt-8 text-center">
+          <Link
+            href="/about"
+            className="inline-block rounded-full bg-white px-6 py-3 text-sm font-semibold text-black shadow hover:scale-105"
+          >
+            This time, don’t settle.
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/comparison/VsAiSection.tsx
+++ b/src/components/comparison/VsAiSection.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useEffect } from 'react';
+import { motion, useAnimation } from 'framer-motion';
+import Link from 'next/link';
+
+export default function VsAiSection() {
+  const aiControls = useAnimation();
+  const nprControls = useAnimation();
+
+  useEffect(() => {
+    aiControls.start({
+      filter: 'grayscale(1) blur(2px)',
+      opacity: 0.5,
+      transition: { delay: 3, duration: 1 },
+    });
+    nprControls.start({ opacity: [0, 1], scale: [0.95, 1], transition: { delay: 3, duration: 1 } });
+  }, [aiControls, nprControls]);
+
+  return (
+    <section className="border-b bg-white py-[clamp(5rem,10vw,8rem)] text-black">
+      <div className="container mx-auto space-y-10 px-4">
+        <h2 className="text-center text-[clamp(1.75rem,3.5vw,2.5rem)] font-bold tracking-tight">
+          NPR Media vs AI
+        </h2>
+        <p className="text-center text-[clamp(0.9rem,1.6vw,1.125rem)]">
+          AI doesn’t think. It predicts. We build from principle, not probability.
+        </p>
+
+        <div className="grid gap-8 md:grid-cols-2">
+          <motion.div
+            initial={{ opacity: 1, filter: 'grayscale(0) blur(0px)' }}
+            animate={aiControls}
+            className="space-y-4 rounded-xl border p-6"
+          >
+            <div className="font-semibold">AI Limitations</div>
+            <ul className="list-disc space-y-1 pl-5 text-sm">
+              <li>No strategic prioritization</li>
+              <li>No creative foresight</li>
+              <li>No brand context</li>
+              <li>No performance ownership</li>
+              <li>No ethics or accountability</li>
+            </ul>
+            <div className="mt-4 text-sm italic text-gray-500">
+              &quot;10 tips for SEO&quot; … and pages of generic fluff
+            </div>
+          </motion.div>
+
+          <motion.div
+            initial={{ opacity: 0, scale: 0.95 }}
+            animate={nprControls}
+            className="space-y-4 rounded-xl border bg-[var(--color-bg-dark)] p-6 text-[var(--color-text-light)]"
+          >
+            <div className="font-semibold">Human Edge</div>
+            <ul className="list-disc space-y-1 pl-5 text-sm">
+              <li>Strategic tiering based on ROI</li>
+              <li>Behavioral conversion engineering</li>
+              <li>Custom UX psychology per vertical</li>
+              <li>Thought partner on growth</li>
+              <li>Senior-level oversight—not prompts</li>
+            </ul>
+            <div className="mt-4 text-sm text-gray-400 italic">
+              “X wouldn’t exist if we used AI.”
+            </div>
+          </motion.div>
+        </div>
+
+        <div className="pt-8 text-center">
+          <Link
+            href="/pricing"
+            className="inline-block rounded-full bg-[var(--color-accent)] px-6 py-3 text-sm font-semibold text-white shadow hover:scale-105"
+          >
+            Don’t get AI’d. Get outcomes.
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add new comparison page `/why-npr`
- implement `VsAiSection` to highlight NPR Media's advantages over AI tools
- implement `VsAgencySection` to compare NPR Media to bloated agencies
- show sticky call to action as user scrolls

## Testing
- `npx prettier -w src/components/comparison/VsAiSection.tsx src/components/comparison/VsAgencySection.tsx src/components/comparison/FinalStickyCTA.tsx src/app/why-npr/page.tsx`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68536c53e0c0832889d0215f6d756247