### PR TITLE
Refine Why NPR headers and colors

### DIFF
--- a/src/app/why-npr/page.tsx
+++ b/src/app/why-npr/page.tsx
@@ -34,7 +34,7 @@ export default function WhyNprPage() {
     <section>
       <StickyHeader />
       <main
-        className="relative w-full overflow-x-hidden bg-[var(--color-bg-dark)] text-[var(--color-text-light)] space-y-20"
+        className="relative w-full overflow-x-hidden bg-[var(--color-bg-dark)] text-[var(--color-text-light)] space-y-28"
         style={{ paddingTop: 'calc(var(--header-height) + 1rem)' }}
       >
         {/* SECTION 1: NPR Media vs AI */}
@@ -43,18 +43,27 @@ export default function WhyNprPage() {
           className="relative overflow-hidden py-20 bg-[var(--color-bg-dark)] text-[var(--color-text-light)]"
         >
           <div className="pointer-events-none absolute inset-0 -z-10">
-            <div className="absolute -top-10 left-1/2 h-96 w-96 -translate-x-1/2 rounded-full bg-gradient-to-br from-indigo-600 via-purple-600 to-fuchsia-600 opacity-30 blur-3xl" />
+            <div className="absolute -top-10 left-1/2 h-96 w-96 -translate-x-1/2 rounded-full bg-gradient-to-br from-[var(--color-accent)] via-[var(--color-accent-dark)] to-[var(--color-accent)] opacity-30 blur-3xl" />
           </div>
           <div className="container mx-auto max-w-6xl space-y-16 px-4">
             <div className="text-center space-y-2">
               <h1 className="text-[clamp(1.75rem,3.5vw,2.5rem)] font-bold tracking-tight">AI Guesswork vs Human Strategy</h1>
-              <p className="text-[clamp(0.9rem,1.6vw,1.125rem)] text-indigo-200">AI doesn’t think. It predicts. That leaves you with generic output and zero accountability.</p>
-              <p className="mx-auto max-w-xl text-sm text-indigo-200">We craft every build from principle, not probability, owning the performance from concept to launch.</p>
+              <p className="text-[clamp(0.9rem,1.6vw,1.125rem)] text-[var(--color-gray-300)]">AI doesn’t think. It predicts. That leaves you with generic output and zero accountability.</p>
+              <p className="mx-auto max-w-xl text-sm text-[var(--color-gray-300)]">We craft every build from principle, not probability, owning the performance from concept to launch.</p>
             </div>
             <div className="space-y-16">
               <div className="md:grid md:grid-cols-2 md:items-center md:gap-8">
-                <div className="pb-8 text-center md:pb-0 md:text-left">
-                  <h2 className="text-2xl font-bold">What AI Can’t Do</h2>
+                <div className="pb-8 text-center md:pb-0 md:text-left space-y-2">
+                  <h2 className="text-[clamp(1.4rem,3vw,2.25rem)] font-bold">What AI Can’t Do</h2>
+                  <p className="text-sm text-[var(--color-gray-300)]">Where automation falls short</p>
+                  <div className="pt-2">
+                    <a
+                      href="/pricing"
+                      className="inline-block rounded-full bg-gradient-to-r from-[var(--color-accent)] to-[var(--color-accent-dark)] px-4 py-2 text-xs font-semibold text-white shadow transition hover:scale-105"
+                    >
+                      View examples
+                    </a>
+                  </div>
                 </div>
                 <motion.div
                   initial={{ opacity: 0, y: 40 }}
@@ -66,8 +75,17 @@ export default function WhyNprPage() {
                 </motion.div>
               </div>
               <div className="md:grid md:grid-cols-2 md:items-center md:gap-8">
-                <div className="pb-8 text-center md:pb-0 md:text-left">
-                  <h2 className="text-2xl font-bold">How NPR Media Delivers</h2>
+                <div className="pb-8 text-center md:pb-0 md:text-left space-y-2">
+                  <h2 className="text-[clamp(1.4rem,3vw,2.25rem)] font-bold">How NPR Media Delivers</h2>
+                  <p className="text-sm text-[var(--color-gray-300)]">Human-guided strategy for real results</p>
+                  <div className="pt-2">
+                    <a
+                      href="/pricing"
+                      className="inline-block rounded-full bg-gradient-to-r from-[var(--color-accent)] to-[var(--color-accent-dark)] px-4 py-2 text-xs font-semibold text-white shadow transition hover:scale-105"
+                    >
+                      See our approach
+                    </a>
+                  </div>
                 </div>
                 <motion.div
                   initial={{ opacity: 0, y: 40 }}
@@ -79,7 +97,7 @@ export default function WhyNprPage() {
                 </motion.div>
               </div>
             </div>
-            <p className="mx-auto mt-6 max-w-xl text-center text-sm text-indigo-200">
+            <p className="mx-auto mt-6 max-w-xl text-center text-sm text-[var(--color-gray-300)]">
               Leaving growth to algorithms leads to cookie-cutter results. Our strategists own every outcome from start to finish.
             </p>
             <hr className="my-16 h-px border-0 bg-gradient-to-r from-transparent via-white/50 to-transparent" />
@@ -89,7 +107,7 @@ export default function WhyNprPage() {
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
                 transition={{ duration: 0.6 }}
-                className="rounded-lg bg-white/10 p-4 shadow text-white"
+                className="rounded-xl bg-white/10 p-6 shadow-lg text-white"
               >
                 <p className="font-semibold">“Client X wouldn’t exist if we used AI.”</p>
               </motion.div>
@@ -98,7 +116,7 @@ export default function WhyNprPage() {
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
                 transition={{ duration: 0.6, delay: 0.1 }}
-                className="rounded-lg bg-white/10 p-4 shadow text-white"
+                className="rounded-xl bg-white/10 p-6 shadow-lg text-white"
               >
                 <p className="font-semibold">“Our last launch doubled signups after a human-led overhaul.”</p>
               </motion.div>
@@ -112,7 +130,7 @@ export default function WhyNprPage() {
             >
               <div className="w-1/2 pr-4 text-sm">
                 <p className="mb-2 font-semibold">AI output</p>
-                <div className="rounded bg-indigo-900 p-3 text-white">
+                <div className="rounded bg-[var(--color-accent-dark)] p-3 text-white">
                   <TypingText text="10 tips for SEO…" />
                 </div>
               </div>
@@ -133,7 +151,7 @@ export default function WhyNprPage() {
             <div className="pt-8 text-center">
               <a
                 href="/pricing"
-                className="inline-block rounded-full bg-gradient-to-r from-purple-600 to-indigo-600 px-6 py-3 text-sm font-semibold text-white shadow-md ring-1 ring-white/10 transition hover:scale-105"
+                className="inline-block rounded-full bg-gradient-to-r from-[var(--color-accent)] to-[var(--color-accent-dark)] px-6 py-3 text-sm font-semibold text-white shadow-md ring-1 ring-white/10 transition hover:scale-105"
               >
                 Don’t get AI’d. Get outcomes.
               </a>
@@ -151,7 +169,7 @@ export default function WhyNprPage() {
           className="relative overflow-hidden py-20 bg-white text-black"
         >
           <div className="pointer-events-none absolute inset-0 -z-10">
-            <div className="absolute bottom-0 right-1/2 h-96 w-96 translate-x-1/2 rounded-full bg-gradient-to-br from-pink-300 via-purple-400 to-indigo-300 opacity-30 blur-3xl" />
+            <div className="absolute bottom-0 right-1/2 h-96 w-96 translate-x-1/2 rounded-full bg-gradient-to-br from-[var(--color-accent)] via-[var(--color-accent-dark)] to-[var(--color-accent)] opacity-30 blur-3xl" />
           </div>
           <div className="container mx-auto max-w-6xl space-y-16 px-4">
             <div className="md:grid md:grid-cols-2 md:items-center md:gap-8">
@@ -175,24 +193,33 @@ export default function WhyNprPage() {
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
                 transition={{ duration: 0.6 }}
-                className="space-y-2 rounded-lg bg-white p-4 shadow text-gray-800"
+                className="space-y-2 rounded-xl bg-white p-6 shadow-md text-gray-800"
               >
-                <p className="font-semibold">What other firms drag you through</p>
+                <p className="text-lg font-semibold">What other firms drag you through</p>
+                <p className="text-sm text-gray-500">All the extras you don’t need</p>
+                <div className="pt-2">
+                  <a
+                    href="/about"
+                    className="inline-block rounded-full bg-gradient-to-r from-[var(--color-accent)] to-[var(--color-accent-dark)] px-4 py-2 text-xs font-semibold text-white shadow transition hover:scale-105"
+                  >
+                    Choose better
+                  </a>
+                </div>
                 <ul className="space-y-1 text-sm">
                   <li className="flex items-start gap-2">
-                    <Ban className="h-4 w-4 text-pink-500" />
+                    <Ban className="h-4 w-4 text-[var(--color-accent)]" />
                     <span>4-week discovery calls</span>
                   </li>
                   <li className="flex items-start gap-2">
-                    <Ban className="h-4 w-4 text-pink-500" />
+                    <Ban className="h-4 w-4 text-[var(--color-accent)]" />
                     <span>$2k wireframes</span>
                   </li>
                   <li className="flex items-start gap-2">
-                    <Ban className="h-4 w-4 text-pink-500" />
+                    <Ban className="h-4 w-4 text-[var(--color-accent)]" />
                     <span>Slow handoffs</span>
                   </li>
                   <li className="flex items-start gap-2">
-                    <Ban className="h-4 w-4 text-pink-500" />
+                    <Ban className="h-4 w-4 text-[var(--color-accent)]" />
                     <span>No CRO testing</span>
                   </li>
                 </ul>
@@ -202,28 +229,37 @@ export default function WhyNprPage() {
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
                 transition={{ duration: 0.6, delay: 0.1 }}
-                className="space-y-2 rounded-lg bg-white p-4 shadow text-gray-800"
+                className="space-y-2 rounded-xl bg-white p-6 shadow-md text-gray-800"
               >
-                <p className="font-semibold">How we keep projects moving</p>
+                <p className="text-lg font-semibold">How we keep projects moving</p>
+                <p className="text-sm text-gray-500">The NPR no-bloat process</p>
+                <div className="pt-2">
+                  <a
+                    href="/contact"
+                    className="inline-block rounded-full bg-gradient-to-r from-[var(--color-accent)] to-[var(--color-accent-dark)] px-4 py-2 text-xs font-semibold text-white shadow transition hover:scale-105"
+                  >
+                    Start your project
+                  </a>
+                </div>
                 <ul className="space-y-1 text-sm">
                   <li className="flex items-start gap-2">
-                    <CheckCircle2 className="h-4 w-4 text-purple-600" />
+                    <CheckCircle2 className="h-4 w-4 text-[var(--color-accent)]" />
                     <span>Production-grade homepage</span>
                   </li>
                   <li className="flex items-start gap-2">
-                    <CheckCircle2 className="h-4 w-4 text-purple-600" />
+                    <CheckCircle2 className="h-4 w-4 text-[var(--color-accent)]" />
                     <span>9-section CMS site</span>
                   </li>
                   <li className="flex items-start gap-2">
-                    <CheckCircle2 className="h-4 w-4 text-purple-600" />
+                    <CheckCircle2 className="h-4 w-4 text-[var(--color-accent)]" />
                     <span>SOP-aligned builds</span>
                   </li>
                   <li className="flex items-start gap-2">
-                    <CheckCircle2 className="h-4 w-4 text-purple-600" />
+                    <CheckCircle2 className="h-4 w-4 text-[var(--color-accent)]" />
                     <span>Real-time revisions</span>
                   </li>
                   <li className="flex items-start gap-2">
-                    <CheckCircle2 className="h-4 w-4 text-purple-600" />
+                    <CheckCircle2 className="h-4 w-4 text-[var(--color-accent)]" />
                     <span>Vercel-level hosting</span>
                   </li>
                 </ul>
@@ -233,7 +269,7 @@ export default function WhyNprPage() {
             <div className="pt-8 text-center">
               <a
                 href="/about"
-                className="inline-block rounded-full bg-gradient-to-r from-pink-500 to-purple-500 px-6 py-3 text-sm font-semibold text-white shadow-md ring-1 ring-black/10 transition hover:scale-105"
+                className="inline-block rounded-full bg-gradient-to-r from-[var(--color-accent)] to-[var(--color-accent-dark)] px-6 py-3 text-sm font-semibold text-white shadow-md ring-1 ring-black/10 transition hover:scale-105"
               >
                 This time, don’t settle.
               </a>

--- a/src/components/whyNpr/AiCarousel.tsx
+++ b/src/components/whyNpr/AiCarousel.tsx
@@ -65,7 +65,7 @@ export default function AiCarousel() {
                   animate={{ opacity: 1, y: 0 }}
                   exit={{ opacity: 0, y: -30 }}
                   transition={{ duration: 0.5 }}
-                  className="mx-auto w-[clamp(16rem,40vw,22rem)] space-y-4 rounded-lg bg-gradient-to-br from-slate-800 via-gray-800 to-gray-700 p-6 text-center text-gray-100 shadow-xl ring-1 ring-white/10"
+                  className="mx-auto w-[clamp(16rem,40vw,22rem)] space-y-4 rounded-xl border border-white/10 bg-gradient-to-br from-slate-700 via-gray-700 to-gray-600 p-6 text-center text-gray-100 shadow-2xl"
                 >
                   <h2 className="text-2xl font-bold">{title}</h2>
                   <ul className="list-disc space-y-1 pl-5 text-left text-sm">

--- a/src/components/whyNpr/FirmCarousel.tsx
+++ b/src/components/whyNpr/FirmCarousel.tsx
@@ -85,7 +85,7 @@ export default function FirmCarousel() {
                   animate={{ opacity: 1, y: 0 }}
                   exit={{ opacity: 0, y: -30 }}
                   transition={{ duration: 0.5 }}
-                  className="mx-auto w-[clamp(18rem,60vw,28rem)] rounded-lg bg-gradient-to-br from-gray-50 via-white to-gray-200 p-6 text-black shadow-xl ring-1 ring-black/5"
+                  className="mx-auto w-[clamp(18rem,60vw,28rem)] rounded-xl border border-black/10 bg-gradient-to-br from-gray-50 via-white to-gray-200 p-6 text-black shadow-2xl"
                 >
                   <div className="grid grid-cols-[1fr_auto_1fr_auto_1fr] items-center gap-4">
                     <div>

--- a/src/components/whyNpr/NprCarousel.tsx
+++ b/src/components/whyNpr/NprCarousel.tsx
@@ -64,7 +64,7 @@ export default function NprCarousel() {
                   animate={{ opacity: 1, x: 0 }}
                   exit={{ opacity: 0, x: -30 }}
                   transition={{ duration: 0.5 }}
-                  className="mx-auto w-[clamp(16rem,40vw,22rem)] space-y-4 rounded-lg bg-gradient-to-br from-purple-700 via-indigo-800 to-indigo-900 p-6 text-center text-gray-100 shadow-xl ring-1 ring-white/10"
+                  className="mx-auto w-[clamp(16rem,40vw,22rem)] space-y-4 rounded-xl border border-white/10 bg-gradient-to-br from-[var(--color-accent-dark)] via-[var(--color-accent)] to-[var(--color-accent-dark)] p-6 text-center text-gray-100 shadow-2xl"
                 >
                   <h2 className="text-2xl font-bold">{title}</h2>
                   <ul className="list-disc space-y-1 pl-5 text-left text-sm">


### PR DESCRIPTION
## Summary
- match colors on Why NPR page to accent palette
- enlarge group headers for improved emphasis
- adjust CTA and icon colors to accent tones
- refine NprCarousel card styling for consistent theme

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_685871c4eaa08328b7dffd11e3a3ea49