### PR TITLE
Improve section transitions

### DIFF
--- a/src/app/why-npr/page.tsx
+++ b/src/app/why-npr/page.tsx
@@ -75,8 +75,12 @@ export default function WhyNprPage() {
                   <AiCarousel />
                 </motion.div>
               </div>
-              <p className="text-center text-sm font-semibold text-gray-400">Here&rsquo;s where we step in.</p>
-              <div className="md:grid md:grid-cols-2 md:items-center md:gap-8">
+              <div className="space-y-1 text-center">
+                <h2 className="text-xl font-bold text-gray-100">Here&rsquo;s where we step in</h2>
+                <p className="text-sm text-gray-400">Real humans refine the data and own the outcome.</p>
+                <ScrollCue href="#npr-delivers" className="mx-auto mt-2 text-[var(--color-accent)]" />
+              </div>
+              <div id="npr-delivers" className="md:grid md:grid-cols-2 md:items-center md:gap-8">
                 <div className="pb-8 text-center md:pb-0 md:text-left space-y-2">
                   <h2 className="text-3xl sm:text-4xl font-bold">How NPR Media Delivers</h2>
                   <p className="text-sm text-gray-300">Hands-on strategy that actually moves the needle</p>

--- a/src/app/why-npr/page.tsx
+++ b/src/app/why-npr/page.tsx
@@ -49,8 +49,8 @@ export default function WhyNprPage() {
           <div className="container mx-auto max-w-6xl space-y-12 px-4">
             <div className="text-center space-y-2">
               <h1 className="text-[clamp(2rem,4vw,3rem)] font-bold tracking-tight">Why Human Strategy Beats AI Guesswork</h1>
-              <p className="text-[clamp(0.9rem,1.6vw,1.125rem)] text-gray-300">Algorithms only predict&mdash;they don&rsquo;t truly understand your customer.</p>
-              <p className="mx-auto max-w-xl text-sm text-gray-300">Our team builds on proven principles and stays accountable from concept through launch.</p>
+              <p className="text-[clamp(0.9rem,1.6vw,1.125rem)] text-gray-300">AI can parse data but it can&rsquo;t read minds or context.</p>
+              <p className="mx-auto max-w-xl text-sm text-gray-300">Our strategists apply lived experience and own the results from concept to launch.</p>
             </div>
             <div className="space-y-12">
               <div className="md:grid md:grid-cols-2 md:items-center md:gap-8">
@@ -75,6 +75,7 @@ export default function WhyNprPage() {
                   <AiCarousel />
                 </motion.div>
               </div>
+              <p className="text-center text-sm font-semibold text-gray-400">Here&rsquo;s where we step in.</p>
               <div className="md:grid md:grid-cols-2 md:items-center md:gap-8">
                 <div className="pb-8 text-center md:pb-0 md:text-left space-y-2">
                   <h2 className="text-3xl sm:text-4xl font-bold">How NPR Media Delivers</h2>
@@ -99,7 +100,7 @@ export default function WhyNprPage() {
               </div>
             </div>
             <p className="mx-auto mt-6 max-w-xl text-center text-sm text-gray-300">
-              Handing growth to algorithms means more of the same. Our strategists stay accountable from first idea to final metric.
+              Leaving growth to algorithms only repeats old mistakes. We build every campaign hands-on and measure success by your metrics.
             </p>
             <hr className="my-16 h-px border-0 bg-gradient-to-r from-transparent via-white/50 to-transparent" />
             <div className="grid gap-6 md:grid-cols-2">
@@ -122,6 +123,7 @@ export default function WhyNprPage() {
                 <p className="font-semibold">“Our last launch doubled signups after a human-led overhaul.”</p>
               </motion.div>
             </div>
+            <p className="mt-6 text-center text-sm text-gray-600">Skip the bloat and keep momentum with a senior crew measured on outcomes.</p>
             <hr className="my-16 h-px border-0 bg-gradient-to-r from-transparent via-white/50 to-transparent" />
             <motion.div
               initial={{ opacity: 0 }}
@@ -227,6 +229,7 @@ export default function WhyNprPage() {
                   </li>
                 </ul>
               </motion.div>
+              <p className="text-center text-sm font-semibold text-gray-500">Here&rsquo;s how we do it differently.</p>
               <motion.div
                 initial={{ opacity: 0, y: 20 }}
                 whileInView={{ opacity: 1, y: 0 }}

--- a/src/app/why-npr/page.tsx
+++ b/src/app/why-npr/page.tsx
@@ -2,6 +2,7 @@
 
 import StickyHeader from '@/components/global/Header'
 import FooterSection from '@/components/global/Footer'
+import ScrollCue from '@/components/global/ScrollCue'
 import WaveDivider from '@/components/whyNpr/WaveDivider'
 import AiCarousel from '@/components/whyNpr/AiCarousel'
 import NprCarousel from '@/components/whyNpr/NprCarousel'
@@ -34,7 +35,7 @@ export default function WhyNprPage() {
     <section>
       <StickyHeader />
       <main
-        className="relative w-full overflow-x-hidden bg-[var(--color-bg-dark)] text-[var(--color-text-light)] space-y-20"
+        className="relative w-full overflow-x-hidden bg-[var(--color-bg-dark)] text-[var(--color-text-light)] space-y-24"
         style={{ paddingTop: 'calc(var(--header-height) + 1rem)' }}
       >
         {/* SECTION 1: NPR Media vs AI */}
@@ -43,18 +44,27 @@ export default function WhyNprPage() {
           className="relative overflow-hidden py-20 bg-[var(--color-bg-dark)] text-[var(--color-text-light)]"
         >
           <div className="pointer-events-none absolute inset-0 -z-10">
-            <div className="absolute -top-10 left-1/2 h-96 w-96 -translate-x-1/2 rounded-full bg-gradient-to-br from-indigo-600 via-purple-600 to-fuchsia-600 opacity-30 blur-3xl" />
+            <div className="absolute -top-10 left-1/2 h-96 w-96 -translate-x-1/2 rounded-full bg-gradient-to-br from-[var(--color-accent)] via-pink-500 to-[var(--color-accent-dark)] opacity-30 blur-3xl" />
           </div>
-          <div className="container mx-auto max-w-6xl space-y-16 px-4">
+          <div className="container mx-auto max-w-6xl space-y-12 px-4">
             <div className="text-center space-y-2">
-              <h1 className="text-[clamp(1.75rem,3.5vw,2.5rem)] font-bold tracking-tight">AI Guesswork vs Human Strategy</h1>
-              <p className="text-[clamp(0.9rem,1.6vw,1.125rem)] text-indigo-200">AI doesn’t think. It predicts. That leaves you with generic output and zero accountability.</p>
-              <p className="mx-auto max-w-xl text-sm text-indigo-200">We craft every build from principle, not probability, owning the performance from concept to launch.</p>
+              <h1 className="text-[clamp(2rem,4vw,3rem)] font-bold tracking-tight">Why Human Strategy Beats AI Guesswork</h1>
+              <p className="text-[clamp(0.9rem,1.6vw,1.125rem)] text-gray-300">Algorithms only predict&mdash;they don&rsquo;t truly understand your customer.</p>
+              <p className="mx-auto max-w-xl text-sm text-gray-300">Our team builds on proven principles and stays accountable from concept through launch.</p>
             </div>
-            <div className="space-y-16">
+            <div className="space-y-12">
               <div className="md:grid md:grid-cols-2 md:items-center md:gap-8">
-                <div className="pb-8 text-center md:pb-0 md:text-left">
-                  <h2 className="text-2xl font-bold">What AI Can’t Do</h2>
+                <div className="pb-8 text-center md:pb-0 md:text-left space-y-2">
+                  <h2 className="text-3xl sm:text-4xl font-bold">What AI Can’t Do</h2>
+                  <p className="text-sm text-gray-300">Where automation simply can&rsquo;t compete</p>
+                  <div className="pt-2">
+                    <a
+                      href="/pricing"
+                      className="inline-block rounded-full bg-gradient-to-r from-[var(--color-accent)] to-[var(--color-accent-dark)] px-4 py-2 text-xs font-semibold text-white shadow transition hover:scale-105"
+                    >
+                      See the difference
+                    </a>
+                  </div>
                 </div>
                 <motion.div
                   initial={{ opacity: 0, y: 40 }}
@@ -66,8 +76,17 @@ export default function WhyNprPage() {
                 </motion.div>
               </div>
               <div className="md:grid md:grid-cols-2 md:items-center md:gap-8">
-                <div className="pb-8 text-center md:pb-0 md:text-left">
-                  <h2 className="text-2xl font-bold">How NPR Media Delivers</h2>
+                <div className="pb-8 text-center md:pb-0 md:text-left space-y-2">
+                  <h2 className="text-3xl sm:text-4xl font-bold">How NPR Media Delivers</h2>
+                  <p className="text-sm text-gray-300">Hands-on strategy that actually moves the needle</p>
+                  <div className="pt-2">
+                    <a
+                      href="/pricing"
+                      className="inline-block rounded-full bg-gradient-to-r from-[var(--color-accent)] to-[var(--color-accent-dark)] px-4 py-2 text-xs font-semibold text-white shadow transition hover:scale-105"
+                    >
+                      Explore our approach
+                    </a>
+                  </div>
                 </div>
                 <motion.div
                   initial={{ opacity: 0, y: 40 }}
@@ -79,8 +98,8 @@ export default function WhyNprPage() {
                 </motion.div>
               </div>
             </div>
-            <p className="mx-auto mt-6 max-w-xl text-center text-sm text-indigo-200">
-              Leaving growth to algorithms leads to cookie-cutter results. Our strategists own every outcome from start to finish.
+            <p className="mx-auto mt-6 max-w-xl text-center text-sm text-gray-300">
+              Handing growth to algorithms means more of the same. Our strategists stay accountable from first idea to final metric.
             </p>
             <hr className="my-16 h-px border-0 bg-gradient-to-r from-transparent via-white/50 to-transparent" />
             <div className="grid gap-6 md:grid-cols-2">
@@ -89,7 +108,7 @@ export default function WhyNprPage() {
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
                 transition={{ duration: 0.6 }}
-                className="rounded-lg bg-white/10 p-4 shadow text-white"
+                className="rounded-xl bg-white/10 p-6 shadow-lg text-white"
               >
                 <p className="font-semibold">“Client X wouldn’t exist if we used AI.”</p>
               </motion.div>
@@ -98,7 +117,7 @@ export default function WhyNprPage() {
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
                 transition={{ duration: 0.6, delay: 0.1 }}
-                className="rounded-lg bg-white/10 p-4 shadow text-white"
+                className="rounded-xl bg-white/10 p-6 shadow-lg text-white"
               >
                 <p className="font-semibold">“Our last launch doubled signups after a human-led overhaul.”</p>
               </motion.div>
@@ -133,14 +152,16 @@ export default function WhyNprPage() {
             <div className="pt-8 text-center">
               <a
                 href="/pricing"
-                className="inline-block rounded-full bg-gradient-to-r from-purple-600 to-indigo-600 px-6 py-3 text-sm font-semibold text-white shadow-md ring-1 ring-white/10 transition hover:scale-105"
+                className="inline-block rounded-full bg-gradient-to-r from-[var(--color-accent)] to-[var(--color-accent-dark)] px-6 py-3 text-sm font-semibold text-white shadow-md ring-1 ring-white/10 transition hover:scale-105"
               >
                 Don’t get AI’d. Get outcomes.
               </a>
             </div>
             <p className="mt-10 text-center text-sm font-semibold text-gray-600">
-              Next, see how we outperform typical agencies.
+              AI isn&rsquo;t your only risk. Bloated agencies drain budgets and momentum.
+              Keep scrolling to see how our lean team drives faster wins.
             </p>
+            <ScrollCue href="#vs-firms" className="mx-auto mt-4 text-[var(--color-accent)]" />
           </div>
         </section>
         <WaveDivider className="text-gray-100" />
@@ -151,14 +172,14 @@ export default function WhyNprPage() {
           className="relative overflow-hidden py-20 bg-white text-black"
         >
           <div className="pointer-events-none absolute inset-0 -z-10">
-            <div className="absolute bottom-0 right-1/2 h-96 w-96 translate-x-1/2 rounded-full bg-gradient-to-br from-pink-300 via-purple-400 to-indigo-300 opacity-30 blur-3xl" />
+            <div className="absolute bottom-0 right-1/2 h-96 w-96 translate-x-1/2 rounded-full bg-gradient-to-br from-[var(--color-accent)] via-pink-400 to-[var(--color-accent-dark)] opacity-30 blur-3xl" />
           </div>
-          <div className="container mx-auto max-w-6xl space-y-16 px-4">
+          <div className="container mx-auto max-w-6xl space-y-12 px-4">
             <div className="md:grid md:grid-cols-2 md:items-center md:gap-8">
               <div className="text-center md:text-left space-y-4">
-                <h1 className="text-[clamp(1.75rem,3.5vw,2.5rem)] font-bold tracking-tight">Agency Bloat vs NPR Media</h1>
-                <p className="text-[clamp(0.9rem,1.6vw,1.125rem)] text-gray-600">Most agencies sell time. We sell outcomes.</p>
-                <p className="mx-auto max-w-xl text-sm text-gray-600 md:mx-0">Big shops pad projects with junior talent and endless steps. Our senior strike team ships fast and owns the metrics.</p>
+                <h1 className="text-[clamp(2rem,4vw,3rem)] font-bold tracking-tight">Agency Bloat vs NPR Media</h1>
+                <p className="text-[clamp(0.9rem,1.6vw,1.125rem)] text-gray-600">AI tools won&rsquo;t own your numbers&mdash;and neither will bloated agencies. While others bill hours, we deliver outcomes.</p>
+                <p className="mx-auto max-w-xl text-sm text-gray-600 md:mx-0">Large firms pad projects with juniors and endless steps. Our senior strike team ships fast and stands behind every metric.</p>
               </div>
               <motion.div
                 initial={{ opacity: 0, y: 40 }}
@@ -175,9 +196,18 @@ export default function WhyNprPage() {
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
                 transition={{ duration: 0.6 }}
-                className="space-y-2 rounded-lg bg-white p-4 shadow text-gray-800"
+                className="space-y-2 rounded-xl bg-white p-6 shadow-md text-gray-800"
               >
-                <p className="font-semibold">What other firms drag you through</p>
+                <p className="text-lg font-semibold">What other firms drag you through</p>
+                <p className="text-sm text-gray-500">Extras you don&rsquo;t actually need</p>
+                <div className="pt-2">
+                  <a
+                    href="/about"
+                    className="inline-block rounded-full bg-gradient-to-r from-[var(--color-accent)] to-[var(--color-accent-dark)] px-4 py-2 text-xs font-semibold text-white shadow transition hover:scale-105"
+                  >
+                    Break free
+                  </a>
+                </div>
                 <ul className="space-y-1 text-sm">
                   <li className="flex items-start gap-2">
                     <Ban className="h-4 w-4 text-pink-500" />
@@ -202,28 +232,37 @@ export default function WhyNprPage() {
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
                 transition={{ duration: 0.6, delay: 0.1 }}
-                className="space-y-2 rounded-lg bg-white p-4 shadow text-gray-800"
+                className="space-y-2 rounded-xl bg-white p-6 shadow-md text-gray-800"
               >
-                <p className="font-semibold">How we keep projects moving</p>
+                <p className="text-lg font-semibold">How we keep projects moving</p>
+                <p className="text-sm text-gray-500">The NPR no-bloat process</p>
+                <div className="pt-2">
+                  <a
+                    href="/contact"
+                    className="inline-block rounded-full bg-gradient-to-r from-[var(--color-accent)] to-[var(--color-accent-dark)] px-4 py-2 text-xs font-semibold text-white shadow transition hover:scale-105"
+                  >
+                    Start winning
+                  </a>
+                </div>
                 <ul className="space-y-1 text-sm">
                   <li className="flex items-start gap-2">
-                    <CheckCircle2 className="h-4 w-4 text-purple-600" />
+                    <CheckCircle2 className="h-4 w-4 text-[var(--color-accent)]" />
                     <span>Production-grade homepage</span>
                   </li>
                   <li className="flex items-start gap-2">
-                    <CheckCircle2 className="h-4 w-4 text-purple-600" />
+                    <CheckCircle2 className="h-4 w-4 text-[var(--color-accent)]" />
                     <span>9-section CMS site</span>
                   </li>
                   <li className="flex items-start gap-2">
-                    <CheckCircle2 className="h-4 w-4 text-purple-600" />
+                    <CheckCircle2 className="h-4 w-4 text-[var(--color-accent)]" />
                     <span>SOP-aligned builds</span>
                   </li>
                   <li className="flex items-start gap-2">
-                    <CheckCircle2 className="h-4 w-4 text-purple-600" />
+                    <CheckCircle2 className="h-4 w-4 text-[var(--color-accent)]" />
                     <span>Real-time revisions</span>
                   </li>
                   <li className="flex items-start gap-2">
-                    <CheckCircle2 className="h-4 w-4 text-purple-600" />
+                    <CheckCircle2 className="h-4 w-4 text-[var(--color-accent)]" />
                     <span>Vercel-level hosting</span>
                   </li>
                 </ul>
@@ -233,11 +272,12 @@ export default function WhyNprPage() {
             <div className="pt-8 text-center">
               <a
                 href="/about"
-                className="inline-block rounded-full bg-gradient-to-r from-pink-500 to-purple-500 px-6 py-3 text-sm font-semibold text-white shadow-md ring-1 ring-black/10 transition hover:scale-105"
+                className="inline-block rounded-full bg-gradient-to-r from-[var(--color-accent)] to-[var(--color-accent-dark)] px-6 py-3 text-sm font-semibold text-white shadow-md ring-1 ring-black/10 transition hover:scale-105"
               >
                 This time, don’t settle.
               </a>
             </div>
+            <ScrollCue href="#footer" className="mx-auto mt-4 text-[var(--color-accent)]" />
           </div>
         </section>
         <WaveDivider flip className="text-gray-100" />

--- a/src/app/why-npr/page.tsx
+++ b/src/app/why-npr/page.tsx
@@ -196,6 +196,7 @@ export default function WhyNprPage() {
               </motion.div>
             </div>
             <hr className="my-16 h-px border-0 bg-gradient-to-r from-transparent via-gray-400 to-transparent" />
+            <p className="text-center text-sm font-semibold text-gray-500">Here&rsquo;s how we do it differently.</p>
             <div className="grid gap-8 text-sm md:grid-cols-2">
               <motion.div
                 initial={{ opacity: 0, y: 20 }}
@@ -233,7 +234,6 @@ export default function WhyNprPage() {
                   </li>
                 </ul>
               </motion.div>
-              <p className="text-center text-sm font-semibold text-gray-500">Here&rsquo;s how we do it differently.</p>
               <motion.div
                 initial={{ opacity: 0, y: 20 }}
                 whileInView={{ opacity: 1, y: 0 }}

--- a/src/components/global/Footer.tsx
+++ b/src/components/global/Footer.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link'
 
 export default function Footer() {
   return (
-    <footer className="bg-[var(--color-bg-dark)] text-[var(--color-text-light)] border-t px-[clamp(1rem,4vw,3rem)] py-[clamp(2.5rem,6vw,4rem)] text-[clamp(0.75rem,1vw,0.875rem)] text-center">
+    <footer id="footer" className="bg-[var(--color-bg-dark)] text-[var(--color-text-light)] border-t px-[clamp(1rem,4vw,3rem)] py-[clamp(2.5rem,6vw,4rem)] text-[clamp(0.75rem,1vw,0.875rem)] text-center">
       <div className="max-w-6xl mx-auto flex flex-col md:flex-row justify-between items-center gap-4">
         <p>&copy; {new Date().getFullYear()} NPR Media. All rights reserved.</p>
         <div className="flex gap-4">

--- a/src/components/global/ScrollCue.tsx
+++ b/src/components/global/ScrollCue.tsx
@@ -16,7 +16,7 @@ export default function ScrollCue({ href, className }: ScrollCueProps) {
       viewport={{ once: true }}
       animate={{ y: [0, 6, 0] }}
       transition={{ duration: 1.2, repeat: Infinity }}
-      className={`block ${className}`}
+      className={`block w-fit mx-auto text-center ${className}`}
     >
       <ChevronDown className="h-10 w-10" />
     </motion.a>

--- a/src/components/global/ScrollCue.tsx
+++ b/src/components/global/ScrollCue.tsx
@@ -18,7 +18,7 @@ export default function ScrollCue({ href, className }: ScrollCueProps) {
       transition={{ duration: 1.2, repeat: Infinity }}
       className={`block ${className}`}
     >
-      <ChevronDown className="h-6 w-6" />
+      <ChevronDown className="h-10 w-10" />
     </motion.a>
   )
 }

--- a/src/components/global/ScrollCue.tsx
+++ b/src/components/global/ScrollCue.tsx
@@ -1,0 +1,24 @@
+'use client'
+import { motion } from 'framer-motion'
+import { ChevronDown } from 'lucide-react'
+
+interface ScrollCueProps {
+  href: string
+  className?: string
+}
+
+export default function ScrollCue({ href, className }: ScrollCueProps) {
+  return (
+    <motion.a
+      href={href}
+      initial={{ opacity: 0, y: -5 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+      animate={{ y: [0, 6, 0] }}
+      transition={{ duration: 1.2, repeat: Infinity }}
+      className={`block ${className}`}
+    >
+      <ChevronDown className="h-6 w-6" />
+    </motion.a>
+  )
+}

--- a/src/components/whyNpr/AiCarousel.tsx
+++ b/src/components/whyNpr/AiCarousel.tsx
@@ -81,7 +81,8 @@ export default function AiCarousel() {
         ))}
       </div>
       <ChevronDown
-        className="pointer-events-none absolute bottom-2 left-1/2 h-8 w-8 -translate-x-1/2 animate-bounce text-[var(--color-accent)]"
+        style={{ bottom: '25%' }}
+        className="pointer-events-none absolute left-1/2 h-8 w-8 -translate-x-1/2 animate-bounce text-[var(--color-accent)]"
       />
     </div>
   )

--- a/src/components/whyNpr/AiCarousel.tsx
+++ b/src/components/whyNpr/AiCarousel.tsx
@@ -81,7 +81,7 @@ export default function AiCarousel() {
         ))}
       </div>
       <ChevronDown
-        className="pointer-events-none absolute bottom-8 left-1/2 h-8 w-8 -translate-x-1/2 animate-bounce text-[var(--color-accent)]"
+        className="pointer-events-none absolute bottom-4 left-1/2 h-8 w-8 -translate-x-1/2 animate-bounce text-[var(--color-accent)]"
       />
     </div>
   )

--- a/src/components/whyNpr/AiCarousel.tsx
+++ b/src/components/whyNpr/AiCarousel.tsx
@@ -2,6 +2,7 @@
 
 import { AnimatePresence, motion } from 'framer-motion'
 import { useEffect, useRef, useState } from 'react'
+import { ChevronDown, ChevronRight } from 'lucide-react'
 
 const aiSlides = [
   'Human-Centric Problem Framing',
@@ -79,6 +80,12 @@ export default function AiCarousel() {
           </section>
         ))}
       </div>
+      <ChevronDown
+        className="pointer-events-none absolute bottom-4 left-1/2 h-8 w-8 -translate-x-1/2 animate-bounce text-[var(--color-accent)]"
+      />
+      <ChevronRight
+        className="pointer-events-none absolute right-4 top-1/2 h-8 w-8 -translate-y-1/2 animate-bounce text-[var(--color-accent)]"
+      />
     </div>
   )
 }

--- a/src/components/whyNpr/AiCarousel.tsx
+++ b/src/components/whyNpr/AiCarousel.tsx
@@ -2,7 +2,7 @@
 
 import { AnimatePresence, motion } from 'framer-motion'
 import { useEffect, useRef, useState } from 'react'
-import { ChevronDown, ChevronRight } from 'lucide-react'
+import { ChevronDown } from 'lucide-react'
 
 const aiSlides = [
   'Human-Centric Problem Framing',
@@ -82,9 +82,6 @@ export default function AiCarousel() {
       </div>
       <ChevronDown
         className="pointer-events-none absolute bottom-4 left-1/2 h-8 w-8 -translate-x-1/2 animate-bounce text-[var(--color-accent)]"
-      />
-      <ChevronRight
-        className="pointer-events-none absolute right-4 top-1/2 h-8 w-8 -translate-y-1/2 animate-bounce text-[var(--color-accent)]"
       />
     </div>
   )

--- a/src/components/whyNpr/AiCarousel.tsx
+++ b/src/components/whyNpr/AiCarousel.tsx
@@ -81,7 +81,7 @@ export default function AiCarousel() {
         ))}
       </div>
       <ChevronDown
-        className="pointer-events-none absolute bottom-4 left-1/2 h-8 w-8 -translate-x-1/2 animate-bounce text-[var(--color-accent)]"
+        className="pointer-events-none absolute bottom-8 left-1/2 h-8 w-8 -translate-x-1/2 animate-bounce text-[var(--color-accent)]"
       />
     </div>
   )

--- a/src/components/whyNpr/AiCarousel.tsx
+++ b/src/components/whyNpr/AiCarousel.tsx
@@ -81,7 +81,7 @@ export default function AiCarousel() {
         ))}
       </div>
       <ChevronDown
-        className="pointer-events-none absolute bottom-4 left-1/2 h-8 w-8 -translate-x-1/2 animate-bounce text-[var(--color-accent)]"
+        className="pointer-events-none absolute bottom-2 left-1/2 h-8 w-8 -translate-x-1/2 animate-bounce text-[var(--color-accent)]"
       />
     </div>
   )

--- a/src/components/whyNpr/AiCarousel.tsx
+++ b/src/components/whyNpr/AiCarousel.tsx
@@ -65,7 +65,7 @@ export default function AiCarousel() {
                   animate={{ opacity: 1, y: 0 }}
                   exit={{ opacity: 0, y: -30 }}
                   transition={{ duration: 0.5 }}
-                  className="mx-auto w-[clamp(16rem,40vw,22rem)] space-y-4 rounded-lg bg-gradient-to-br from-slate-800 via-gray-800 to-gray-700 p-6 text-center text-gray-100 shadow-xl ring-1 ring-white/10"
+                  className="mx-auto w-[clamp(16rem,40vw,22rem)] space-y-4 rounded-xl border border-white/10 bg-[var(--color-card)] p-6 text-center text-gray-100 shadow-2xl"
                 >
                   <h2 className="text-2xl font-bold">{title}</h2>
                   <ul className="list-disc space-y-1 pl-5 text-left text-sm">

--- a/src/components/whyNpr/FirmCarousel.tsx
+++ b/src/components/whyNpr/FirmCarousel.tsx
@@ -2,7 +2,7 @@
 
 import { AnimatePresence, motion } from 'framer-motion'
 import { useEffect, useRef, useState } from 'react'
-import { ArrowRight, ChevronDown, ChevronRight } from 'lucide-react'
+import { ArrowRight, ChevronDown } from 'lucide-react'
 
 const slides = [
   {
@@ -111,9 +111,6 @@ export default function FirmCarousel() {
       </div>
       <ChevronDown
         className="pointer-events-none absolute bottom-4 left-1/2 h-8 w-8 -translate-x-1/2 animate-bounce text-[var(--color-accent)]"
-      />
-      <ChevronRight
-        className="pointer-events-none absolute right-4 top-1/2 h-8 w-8 -translate-y-1/2 animate-bounce text-[var(--color-accent)]"
       />
     </div>
   )

--- a/src/components/whyNpr/FirmCarousel.tsx
+++ b/src/components/whyNpr/FirmCarousel.tsx
@@ -110,7 +110,8 @@ export default function FirmCarousel() {
         ))}
       </div>
       <ChevronDown
-        className="pointer-events-none absolute bottom-2 left-1/2 h-8 w-8 -translate-x-1/2 animate-bounce text-[var(--color-accent)]"
+        style={{ bottom: '25%' }}
+        className="pointer-events-none absolute left-1/2 h-8 w-8 -translate-x-1/2 animate-bounce text-[var(--color-accent)]"
       />
     </div>
   )

--- a/src/components/whyNpr/FirmCarousel.tsx
+++ b/src/components/whyNpr/FirmCarousel.tsx
@@ -2,7 +2,7 @@
 
 import { AnimatePresence, motion } from 'framer-motion'
 import { useEffect, useRef, useState } from 'react'
-import { ArrowRight } from 'lucide-react'
+import { ArrowRight, ChevronDown, ChevronRight } from 'lucide-react'
 
 const slides = [
   {
@@ -109,6 +109,12 @@ export default function FirmCarousel() {
           </section>
         ))}
       </div>
+      <ChevronDown
+        className="pointer-events-none absolute bottom-4 left-1/2 h-8 w-8 -translate-x-1/2 animate-bounce text-[var(--color-accent)]"
+      />
+      <ChevronRight
+        className="pointer-events-none absolute right-4 top-1/2 h-8 w-8 -translate-y-1/2 animate-bounce text-[var(--color-accent)]"
+      />
     </div>
   )
 }

--- a/src/components/whyNpr/FirmCarousel.tsx
+++ b/src/components/whyNpr/FirmCarousel.tsx
@@ -85,7 +85,7 @@ export default function FirmCarousel() {
                   animate={{ opacity: 1, y: 0 }}
                   exit={{ opacity: 0, y: -30 }}
                   transition={{ duration: 0.5 }}
-                  className="mx-auto w-[clamp(18rem,60vw,28rem)] rounded-lg bg-gradient-to-br from-gray-50 via-white to-gray-200 p-6 text-black shadow-xl ring-1 ring-black/5"
+                  className="mx-auto w-[clamp(18rem,60vw,28rem)] rounded-xl border border-black/10 bg-gradient-to-br from-gray-50 via-white to-gray-200 p-6 text-black shadow-2xl"
                 >
                   <div className="grid grid-cols-[1fr_auto_1fr_auto_1fr] items-center gap-4">
                     <div>

--- a/src/components/whyNpr/FirmCarousel.tsx
+++ b/src/components/whyNpr/FirmCarousel.tsx
@@ -110,7 +110,7 @@ export default function FirmCarousel() {
         ))}
       </div>
       <ChevronDown
-        className="pointer-events-none absolute bottom-4 left-1/2 h-8 w-8 -translate-x-1/2 animate-bounce text-[var(--color-accent)]"
+        className="pointer-events-none absolute bottom-2 left-1/2 h-8 w-8 -translate-x-1/2 animate-bounce text-[var(--color-accent)]"
       />
     </div>
   )

--- a/src/components/whyNpr/NprCarousel.tsx
+++ b/src/components/whyNpr/NprCarousel.tsx
@@ -80,7 +80,8 @@ export default function NprCarousel() {
         ))}
       </div>
       <ChevronRight
-        className="pointer-events-none absolute right-2 top-1/2 h-8 w-8 -translate-y-1/2 animate-bounce text-[var(--color-accent)]"
+        style={{ right: '25%' }}
+        className="pointer-events-none absolute top-1/2 h-8 w-8 -translate-y-1/2 animate-bounce text-[var(--color-accent)]"
       />
     </div>
   )

--- a/src/components/whyNpr/NprCarousel.tsx
+++ b/src/components/whyNpr/NprCarousel.tsx
@@ -2,6 +2,7 @@
 
 import { AnimatePresence, motion } from 'framer-motion'
 import { useEffect, useRef, useState } from 'react'
+import { ChevronDown, ChevronRight } from 'lucide-react'
 
 const slides = [
   'Strategic tiering based on ROI',
@@ -78,6 +79,12 @@ export default function NprCarousel() {
           </section>
         ))}
       </div>
+      <ChevronRight
+        className="pointer-events-none absolute right-4 top-1/2 h-8 w-8 -translate-y-1/2 animate-bounce text-[var(--color-accent)]"
+      />
+      <ChevronDown
+        className="pointer-events-none absolute bottom-4 left-1/2 h-8 w-8 -translate-x-1/2 animate-bounce text-[var(--color-accent)]"
+      />
     </div>
   )
 }

--- a/src/components/whyNpr/NprCarousel.tsx
+++ b/src/components/whyNpr/NprCarousel.tsx
@@ -80,7 +80,7 @@ export default function NprCarousel() {
         ))}
       </div>
       <ChevronRight
-        className="pointer-events-none absolute right-4 top-1/2 h-8 w-8 -translate-y-1/2 animate-bounce text-[var(--color-accent)]"
+        className="pointer-events-none absolute right-2 top-1/2 h-8 w-8 -translate-y-1/2 animate-bounce text-[var(--color-accent)]"
       />
     </div>
   )

--- a/src/components/whyNpr/NprCarousel.tsx
+++ b/src/components/whyNpr/NprCarousel.tsx
@@ -2,7 +2,7 @@
 
 import { AnimatePresence, motion } from 'framer-motion'
 import { useEffect, useRef, useState } from 'react'
-import { ChevronDown, ChevronRight } from 'lucide-react'
+import { ChevronRight } from 'lucide-react'
 
 const slides = [
   'Strategic tiering based on ROI',
@@ -81,9 +81,6 @@ export default function NprCarousel() {
       </div>
       <ChevronRight
         className="pointer-events-none absolute right-4 top-1/2 h-8 w-8 -translate-y-1/2 animate-bounce text-[var(--color-accent)]"
-      />
-      <ChevronDown
-        className="pointer-events-none absolute bottom-4 left-1/2 h-8 w-8 -translate-x-1/2 animate-bounce text-[var(--color-accent)]"
       />
     </div>
   )

--- a/src/components/whyNpr/NprCarousel.tsx
+++ b/src/components/whyNpr/NprCarousel.tsx
@@ -80,8 +80,7 @@ export default function NprCarousel() {
         ))}
       </div>
       <ChevronRight
-        style={{ right: '25%' }}
-        className="pointer-events-none absolute top-1/2 h-8 w-8 -translate-y-1/2 animate-bounce text-[var(--color-accent)]"
+        className="pointer-events-none absolute right-2 top-1/2 h-8 w-8 -translate-y-1/2 animate-bounce text-[var(--color-accent)]"
       />
     </div>
   )

--- a/src/components/whyNpr/NprCarousel.tsx
+++ b/src/components/whyNpr/NprCarousel.tsx
@@ -64,7 +64,7 @@ export default function NprCarousel() {
                   animate={{ opacity: 1, x: 0 }}
                   exit={{ opacity: 0, x: -30 }}
                   transition={{ duration: 0.5 }}
-                  className="mx-auto w-[clamp(16rem,40vw,22rem)] space-y-4 rounded-lg bg-gradient-to-br from-purple-700 via-indigo-800 to-indigo-900 p-6 text-center text-gray-100 shadow-xl ring-1 ring-white/10"
+                  className="mx-auto w-[clamp(16rem,40vw,22rem)] space-y-4 rounded-xl border border-white/10 bg-gradient-to-br from-[var(--color-accent)] via-pink-600 to-[var(--color-accent-dark)] p-6 text-center text-gray-100 shadow-2xl"
                 >
                   <h2 className="text-2xl font-bold">{title}</h2>
                   <ul className="list-disc space-y-1 pl-5 text-left text-sm">


### PR DESCRIPTION
## Summary
- refine copy for smoother section handoff
- tie agency-bloat section to AI critique
- add animated scroll cue

## Testing
- `npx next lint`


------
https://chatgpt.com/codex/tasks/task_e_685871c4eaa08328b7dffd11e3a3ea49