### PR TITLE
Add about page

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import StickyHeader from '@/components/global/Header';
+import FooterSection from '@/components/global/Footer';
+import AboutHero from '@/components/about/Hero';
+import MissionSection from '@/components/about/Mission';
+import TeamSection from '@/components/about/Team';
+import ContactSection from '@/components/homepage/ContactSection';
+
+export default function AboutPage() {
+  return (
+    <section>
+      <StickyHeader />
+      <main className="relative w-full overflow-x-hidden bg-white text-black">
+        <AboutHero />
+        <MissionSection />
+        <TeamSection />
+        <ContactSection />
+      </main>
+      <FooterSection />
+    </section>
+  );
+}

--- a/src/components/about/Hero.tsx
+++ b/src/components/about/Hero.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+export default function AboutHero() {
+  return (
+    <section className="relative flex items-center justify-center bg-[var(--color-bg-dark)] px-[clamp(1rem,4vw,3rem)] py-[clamp(5rem,10vw,8rem)] text-[var(--color-text-light)]">
+      <div className="mx-auto max-w-2xl space-y-4 text-center">
+        <h1 className="text-[clamp(2rem,4vw,3rem)] font-bold">About NPR Media</h1>
+        <p className="text-[clamp(0.9rem,1.6vw,1.125rem)] text-gray-300">
+          We craft high-performance websites and systems that fuel startup growth.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/src/components/about/Mission.tsx
+++ b/src/components/about/Mission.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+export default function MissionSection() {
+  return (
+    <section className="bg-white px-[clamp(1rem,4vw,3rem)] py-[clamp(5rem,10vw,8rem)] text-black">
+      <div className="mx-auto max-w-4xl space-y-6 text-center">
+        <h2 className="text-[clamp(1.75rem,3.5vw,2.5rem)] font-bold">Our Mission</h2>
+        <p className="text-[clamp(0.9rem,1.6vw,1.125rem)] text-gray-700">
+          Empower founders with websites that convert and systems that scale.
+        </p>
+        <div className="mt-10 grid gap-8 text-left md:grid-cols-3">
+          <div className="space-y-2">
+            <h3 className="text-lg font-semibold">Performance</h3>
+            <p className="text-sm text-gray-600">Modern stacks for speed and reliability.</p>
+          </div>
+          <div className="space-y-2">
+            <h3 className="text-lg font-semibold">Partnership</h3>
+            <p className="text-sm text-gray-600">Direct access to senior talent—no bloat.</p>
+          </div>
+          <div className="space-y-2">
+            <h3 className="text-lg font-semibold">Results</h3>
+            <p className="text-sm text-gray-600">We measure success by growth and ROI.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/about/Team.tsx
+++ b/src/components/about/Team.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import Image from 'next/image';
+
+export default function TeamSection() {
+  const team = [
+    {
+      name: 'Nate Rivers',
+      role: 'Founder & Lead Dev',
+      img: 'https://images.unsplash.com/photo-1502685104226-ee32379fefbe?auto=format&fit=crop&w=300&q=60',
+    },
+    {
+      name: 'Sasha Patel',
+      role: 'UX Strategist',
+      img: 'https://images.unsplash.com/photo-1506794778202-cad84cf45f1d?auto=format&fit=crop&w=300&q=60',
+    },
+    {
+      name: 'Miguel Alvarez',
+      role: 'Automation Specialist',
+      img: 'https://images.unsplash.com/photo-1517841905240-472988babdf9?auto=format&fit=crop&w=300&q=60',
+    },
+  ];
+
+  return (
+    <section className="bg-gray-50 px-[clamp(1rem,4vw,3rem)] py-[clamp(5rem,10vw,8rem)] text-black">
+      <div className="mx-auto max-w-4xl space-y-8 text-center">
+        <h2 className="text-[clamp(1.75rem,3.5vw,2.5rem)] font-bold">Meet the Team</h2>
+        <p className="text-[clamp(0.9rem,1.6vw,1.125rem)] text-gray-700">
+          A lean crew of web veterans.
+        </p>
+        <div className="grid gap-8 sm:grid-cols-2 md:grid-cols-3">
+          {team.map((member) => (
+            <div key={member.name} className="space-y-2">
+              <Image
+                src={member.img}
+                alt={member.name}
+                width={300}
+                height={300}
+                className="mx-auto rounded-full object-cover"
+              />
+              <p className="font-semibold">{member.name}</p>
+              <p className="text-sm text-gray-600">{member.role}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- create an `about` route with hero, mission and team sections
- keep brand colours consistent with other pages
- include contact and footer

## Testing
- `npx next lint`

------
https://chatgpt.com/codex/tasks/task_e_6858d07fad208328ae5eeb9e34ab623b