### PR TITLE
Use article images as about page background

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -71,7 +71,24 @@ export default function AboutPage() {
         </section>
 
         {/* Team */}
-        <section className="bg-white text-black py-[clamp(4rem,8vw,6rem)] px-4">
+        <section className="relative bg-white text-black py-[clamp(4rem,8vw,6rem)] px-4">
+          <div className="absolute inset-0 -z-10 grid grid-cols-1 sm:grid-cols-3">
+            <img
+              src="/logos/Article%201%20-%20Template.png"
+              alt="Article 1"
+              className="h-full w-full object-cover"
+            />
+            <img
+              src="/logos/Article%202%20-%20Template.png"
+              alt="Article 2"
+              className="h-full w-full object-cover"
+            />
+            <img
+              src="/logos/Article%203%20-%20Template.png"
+              alt="Article 3"
+              className="h-full w-full object-cover"
+            />
+          </div>
           <div className="mx-auto max-w-4xl text-center space-y-8">
             <h2 className="text-2xl font-bold">Meet the Team</h2>
             <div className="flex justify-center">


### PR DESCRIPTION
## Summary
- update About page's team section with article images

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68603bc2501c832885b91919988f1cd3