### PR TITLE
Add article image collage to CEO section

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -4,6 +4,7 @@ import StickyHeader from '@/components/global/Header'
 import FooterSection from '@/components/global/Footer'
 import ValuesCarousel from '@/components/about/ValuesCarousel'
 import { motion } from 'framer-motion'
+import Image from 'next/image'
 
 export default function AboutPage() {
   return (
@@ -71,8 +72,19 @@ export default function AboutPage() {
         </section>
 
         {/* Team */}
-        <section className="bg-white text-black py-[clamp(4rem,8vw,6rem)] px-4">
-          <div className="mx-auto max-w-4xl text-center space-y-8">
+        <section className="relative bg-white text-black py-[clamp(4rem,8vw,6rem)] px-4">
+          <div className="absolute inset-0 -z-10 flex h-full w-full">
+            <div className="relative flex-1">
+              <Image src="/logos/Article 1 - Template.png" alt="Article 1" fill className="object-cover" />
+            </div>
+            <div className="relative flex-1">
+              <Image src="/logos/Article 2 - Template.png" alt="Article 2" fill className="object-cover" />
+            </div>
+            <div className="relative flex-1">
+              <Image src="/logos/Article 3 - Template.png" alt="Article 3" fill className="object-cover" />
+            </div>
+          </div>
+          <div className="relative mx-auto max-w-4xl text-center space-y-8">
             <h2 className="text-2xl font-bold">Meet the Team</h2>
             <div className="flex justify-center">
               <div className="space-y-2">


### PR DESCRIPTION
## Summary
- add `next/image` import to about page
- display Article 1, 2 and 3 images as a 3-column background for the CEO section

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68603bc2501c832885b91919988f1cd3