### PR TITLE
Apply article logos as about section background

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -71,8 +71,22 @@ export default function AboutPage() {
         </section>
 
         {/* Team */}
-        <section className="bg-white text-black py-[clamp(4rem,8vw,6rem)] px-4">
-          <div className="mx-auto max-w-4xl text-center space-y-8">
+        <section className="relative bg-white text-black py-[clamp(4rem,8vw,6rem)] px-4">
+          <div className="pointer-events-none absolute inset-0 -z-10 grid grid-cols-3">
+            <div
+              className="h-full w-full bg-cover bg-center"
+              style={{ backgroundImage: "url('/logos/Article 1 - Template.png')" }}
+            />
+            <div
+              className="h-full w-full bg-cover bg-center"
+              style={{ backgroundImage: "url('/logos/Article 2 - Template.png')" }}
+            />
+            <div
+              className="h-full w-full bg-cover bg-center"
+              style={{ backgroundImage: "url('/logos/Article 3 - Template.png')" }}
+            />
+          </div>
+          <div className="mx-auto max-w-4xl text-center space-y-8 relative">
             <h2 className="text-2xl font-bold">Meet the Team</h2>
             <div className="flex justify-center">
               <div className="space-y-2">

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -72,7 +72,7 @@ export default function AboutPage() {
 
         {/* Team */}
         <section className="relative bg-white text-black py-[clamp(4rem,8vw,6rem)] px-4">
-          <div className="pointer-events-none absolute inset-0 -z-10 grid grid-cols-3">
+          <div className="pointer-events-none absolute inset-0 z-0 grid grid-cols-3 gap-0">
             <div
               className="h-full w-full bg-cover bg-center"
               style={{ backgroundImage: "url('/logos/Article 1 - Template.png')" }}
@@ -86,7 +86,7 @@ export default function AboutPage() {
               style={{ backgroundImage: "url('/logos/Article 3 - Template.png')" }}
             />
           </div>
-          <div className="mx-auto max-w-4xl text-center space-y-8 relative">
+          <div className="relative z-10 mx-auto max-w-4xl text-center space-y-8">
             <h2 className="text-2xl font-bold">Meet the Team</h2>
             <div className="flex justify-center">
               <div className="space-y-2">

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -75,18 +75,28 @@ export default function AboutPage() {
           <div className="pointer-events-none absolute inset-0 z-0 grid grid-cols-3 gap-0">
             <div
               className="h-full w-full bg-cover bg-center"
-              style={{ backgroundImage: "url('/logos/Article 1 - Template.png')" }}
+              style={{
+                backgroundImage: "url('/logos/Article 1 - Template.png')",
+                filter: 'grayscale(100%) sepia(20%) brightness(110%)',
+              }}
             />
             <div
               className="h-full w-full bg-cover bg-center"
-              style={{ backgroundImage: "url('/logos/Article 2 - Template.png')" }}
+              style={{
+                backgroundImage: "url('/logos/Article 2 - Template.png')",
+                filter: 'grayscale(100%) sepia(20%) brightness(110%)',
+              }}
             />
             <div
               className="h-full w-full bg-cover bg-center"
-              style={{ backgroundImage: "url('/logos/Article 3 - Template.png')" }}
+              style={{
+                backgroundImage: "url('/logos/Article 3 - Template.png')",
+                filter: 'grayscale(100%) sepia(20%) brightness(110%)',
+              }}
             />
           </div>
-          <div className="relative z-10 mx-auto max-w-4xl text-center space-y-8">
+          <div className="pointer-events-none absolute inset-0 z-10 bg-[#f8f3e3]/60" />
+          <div className="relative z-20 mx-auto max-w-4xl text-center space-y-8">
             <h2 className="text-2xl font-bold">Meet the Team</h2>
             <div className="flex justify-center">
               <div className="space-y-2">


### PR DESCRIPTION
## Summary
- display three article logos as the full background of the CEO section on the About page

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68603bc2501c832885b91919988f1cd3