### PR TITLE
Add final CTA component and integrate on missing pages

### DIFF
--- a/cta-summary.md
+++ b/cta-summary.md
@@ -1,0 +1,9 @@
+# CTA Audit Summary
+
+| Page | Status |
+|------|--------|
+| src/app/page.tsx | ✅ CTA found |
+| src/app/about/page.tsx | ✅ CTA found |
+| src/app/pricing/page.tsx | ✳️ CTA created |
+| src/app/why-npr/page.tsx | ✳️ CTA created |
+| src/app/layout.tsx | ⚠️ Skipped (layout) |

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -1,6 +1,7 @@
 import StickyHeader from '@/components/global/Header';
 import FooterSection from '@/components/global/Footer';
 import PricingSection from '@/components/homepage/PricingSection';
+import FinalCTA from '@/components/sections/FinalCTA';
 
 export default function PricingPage() {
   return (
@@ -8,6 +9,7 @@ export default function PricingPage() {
       <StickyHeader />
       <main className="relative w-full overflow-x-hidden bg-white text-black">
         <PricingSection />
+        <FinalCTA />
       </main>
       <FooterSection />
     </section>

--- a/src/app/why-npr/page.tsx
+++ b/src/app/why-npr/page.tsx
@@ -7,6 +7,7 @@ import WaveDivider from '@/components/whyNpr/WaveDivider'
 import AiCarousel from '@/components/whyNpr/AiCarousel'
 import NprCarousel from '@/components/whyNpr/NprCarousel'
 import FirmCarousel from '@/components/whyNpr/FirmCarousel'
+import FinalCTA from '@/components/sections/FinalCTA'
 import { motion, useInView } from 'framer-motion'
 import { useEffect, useRef, useState } from 'react'
 import { Ban, CheckCircle2 } from 'lucide-react'
@@ -288,6 +289,7 @@ export default function WhyNprPage() {
           </div>
         </section>
         <WaveDivider flip className="text-gray-100" />
+        <FinalCTA />
       </main>
       <FooterSection />
     </section>

--- a/src/components/sections/FinalCTA.tsx
+++ b/src/components/sections/FinalCTA.tsx
@@ -1,0 +1,14 @@
+export default function FinalCTA() {
+  return (
+    <section className="bg-neutral-950 text-white py-20 px-6 text-center">
+      <h2 className="text-3xl md:text-4xl font-bold mb-4">Let’s build something legendary</h2>
+      <p className="text-lg mb-6 max-w-2xl mx-auto">
+        We craft websites that drive serious results. Book your strategy call today.
+      </p>
+      <a href="/contact" className="inline-block bg-white text-black font-semibold py-3 px-6 rounded-lg hover:bg-neutral-200 transition">
+        Book Free Discovery Call
+      </a>
+      <p className="text-sm mt-4 text-neutral-400">No pressure. Just clarity and next steps.</p>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- create `FinalCTA` section component
- show new CTA at the bottom of pricing and why-npr pages
- document CTA audit results

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6861de5b697c83288d66253d1570a361