### PR TITLE
Implement contact page with routing utility

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,200 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { motion } from 'framer-motion'
+import { Phone, Mail, CalendarDays } from 'lucide-react'
+
+interface Copy {
+  headline: string
+  subtext: string
+}
+
+export default function ContactPage() {
+  const [copy, setCopy] = useState<Copy>({
+    headline: "Let\u2019s Talk",
+    subtext: 'Tell us about your project and goals.'
+  })
+
+  useEffect(() => {
+    async function loadCopy() {
+      try {
+        // @ts-expect-error optional CMS module
+        const mod = await import('@/content/contact')
+        if (mod.contactCopy) {
+          setCopy((prev) => ({
+            headline: mod.contactCopy.headline || prev.headline,
+            subtext: mod.contactCopy.subtext || prev.subtext,
+          }))
+        }
+      } catch {
+        // no CMS copy available
+      }
+    }
+    loadCopy()
+  }, [])
+
+  const [values, setValues] = useState({ name: '', email: '', summary: '' })
+  const [errors, setErrors] = useState<{ name?: string; email?: string; summary?: string }>({})
+  const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle')
+
+  const validate = () => {
+    const newErrors: { name?: string; email?: string; summary?: string } = {}
+    if (!values.name.trim()) newErrors.name = 'Full name is required'
+    if (!values.email.trim()) newErrors.email = 'Work email is required'
+    else if (!/^\S+@\S+\.\S+$/.test(values.email)) newErrors.email = 'Enter a valid email'
+    if (!values.summary.trim()) newErrors.summary = 'Project summary is required'
+    return newErrors
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const v = validate()
+    setErrors(v)
+    if (Object.keys(v).length) return
+
+    setStatus('loading')
+    try {
+      const res = await fetch('/api/contact', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(values),
+      })
+      if (res.ok) {
+        setStatus('success')
+      } else {
+        throw new Error('Request failed')
+      }
+    } catch {
+      setStatus('error')
+    }
+  }
+
+  return (
+    <main className="flex min-h-screen items-center py-16 px-6 lg:px-12">
+      <motion.div
+        initial={{ opacity: 0, y: 30 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.6 }}
+        className="w-full max-w-3xl mx-auto space-y-8"
+      >
+        <div className="text-center space-y-2">
+          <h1 className="text-4xl md:text-5xl font-bold">{copy.headline}</h1>
+          <p className="text-neutral-600 dark:text-neutral-400">{copy.subtext}</p>
+        </div>
+
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, delay: 0.1 }}
+          className="relative rounded-2xl bg-white dark:bg-neutral-900 p-6 shadow-lg"
+        >
+          <motion.div
+            className="pointer-events-none absolute -inset-2 -z-10 rounded-3xl bg-gradient-to-br from-pink-300 via-purple-300 to-indigo-400 opacity-20 blur-2xl"
+            animate={{ opacity: [0.3, 0.6, 0.3] }}
+            transition={{ duration: 8, repeat: Infinity }}
+          />
+          {status === 'success' ? (
+            <p className="text-center text-green-600">Thanks for reaching out! We&apos;ll be in touch soon.</p>
+          ) : (
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <label className="block text-sm font-medium">
+                Full Name
+                <input
+                  type="text"
+                  value={values.name}
+                  onChange={(e) => setValues({ ...values, name: e.target.value })}
+                  className="mt-1 w-full rounded-md border px-3 py-2 bg-white dark:bg-neutral-800 text-black dark:text-white focus-visible:outline focus-visible:outline-blue-500"
+                  aria-invalid={!!errors.name}
+                  aria-describedby={errors.name ? 'name-error' : undefined}
+                />
+              </label>
+              {errors.name && (
+                <p id="name-error" className="text-sm text-red-600">
+                  {errors.name}
+                </p>
+              )}
+
+              <label className="block text-sm font-medium">
+                Work Email
+                <input
+                  type="email"
+                  required
+                  value={values.email}
+                  onChange={(e) => setValues({ ...values, email: e.target.value })}
+                  className="mt-1 w-full rounded-md border px-3 py-2 bg-white dark:bg-neutral-800 text-black dark:text-white focus-visible:outline focus-visible:outline-blue-500"
+                  aria-invalid={!!errors.email}
+                  aria-describedby={errors.email ? 'email-error' : undefined}
+                />
+              </label>
+              {errors.email && (
+                <p id="email-error" className="text-sm text-red-600">
+                  {errors.email}
+                </p>
+              )}
+
+              <label className="block text-sm font-medium">
+                Project Summary
+                <textarea
+                  rows={5}
+                  value={values.summary}
+                  onChange={(e) => setValues({ ...values, summary: e.target.value })}
+                  className="mt-1 w-full rounded-md border px-3 py-2 bg-white dark:bg-neutral-800 text-black dark:text-white focus-visible:outline focus-visible:outline-blue-500"
+                  aria-invalid={!!errors.summary}
+                  aria-describedby={errors.summary ? 'summary-error' : undefined}
+                ></textarea>
+              </label>
+              {errors.summary && (
+                <p id="summary-error" className="text-sm text-red-600">
+                  {errors.summary}
+                </p>
+              )}
+
+              <button
+                type="submit"
+                disabled={status === 'loading'}
+                className="w-full bg-black text-white py-3 px-6 rounded-xl shadow-lg hover:scale-105 transition disabled:opacity-50"
+              >
+                {status === 'loading' ? (
+                  <span className="inline-block h-5 w-5 animate-spin rounded-full border-2 border-white border-t-transparent"></span>
+                ) : (
+                  'Send Message'
+                )}
+              </button>
+              <p className="text-xs text-neutral-500 italic mt-2">
+                We reply to every serious inquiry within 1 business day.
+              </p>
+            </form>
+          )}
+        </motion.div>
+
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, delay: 0.2 }}
+          className="grid gap-4 md:grid-cols-3 pt-4"
+        >
+          <div className="flex flex-col items-center rounded-xl bg-white dark:bg-neutral-900 p-4 shadow">
+            <Phone className="h-6 w-6 mb-2" />
+            <p className="text-sm">+1 (555) 123-4567</p>
+          </div>
+          <div className="flex flex-col items-center rounded-xl bg-white dark:bg-neutral-900 p-4 shadow">
+            <Mail className="h-6 w-6 mb-2" />
+            <p className="text-sm">contact@npr-media.com</p>
+          </div>
+          <div className="flex flex-col items-center rounded-xl bg-white dark:bg-neutral-900 p-4 shadow">
+            <CalendarDays className="h-6 w-6 mb-2" />
+            <a
+              href="https://calendly.com/example"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm underline"
+            >
+              Book a Call
+            </a>
+          </div>
+        </motion.div>
+      </motion.div>
+    </main>
+  )
+}
+

--- a/src/app/landing/[slug]/page.tsx
+++ b/src/app/landing/[slug]/page.tsx
@@ -1,0 +1,14 @@
+import { routes } from '@/lib/routes'
+import Link from 'next/link'
+
+export default function LandingPage({ params }: { params: { slug: string } }) {
+  return (
+    <main className="min-h-screen flex flex-col items-center justify-center space-y-4 px-6 py-20">
+      <h1 className="text-3xl font-bold">Landing: {params.slug}</h1>
+      <p className="text-center max-w-xl">This is a placeholder landing page.</p>
+      <Link href={routes.contact} className="inline-block bg-black text-white py-3 px-6 rounded-xl shadow hover:scale-105 transition">
+        Contact Us
+      </Link>
+    </main>
+  )
+}

--- a/src/app/why-npr/page.tsx
+++ b/src/app/why-npr/page.tsx
@@ -11,6 +11,7 @@ import FinalCTA from '@/components/sections/FinalCTA'
 import { motion, useInView } from 'framer-motion'
 import { useEffect, useRef, useState } from 'react'
 import { Ban, CheckCircle2 } from 'lucide-react'
+import { routes } from '@/lib/routes'
 
 function TypingText({ text }: { text: string }) {
   const ref = useRef<HTMLDivElement>(null)
@@ -246,7 +247,7 @@ export default function WhyNprPage() {
                 <p className="text-sm text-gray-500">The NPR no-bloat process</p>
                 <div className="pt-2">
                   <a
-                    href="/contact"
+                    href={routes.contact}
                     className="inline-block rounded-full bg-gradient-to-r from-[var(--color-accent)] to-[var(--color-accent-dark)] px-4 py-2 text-xs font-semibold text-white shadow transition hover:scale-105"
                   >
                     Start winning

--- a/src/components/global/Footer.tsx
+++ b/src/components/global/Footer.tsx
@@ -1,10 +1,16 @@
 'use client'
 
 import Link from 'next/link'
+import { routes } from '@/lib/routes'
 
 export default function Footer() {
   return (
     <footer id="footer" className="bg-[var(--color-bg-dark)] text-[var(--color-text-light)] border-t px-[clamp(1rem,4vw,3rem)] py-[clamp(2.5rem,6vw,4rem)] text-[clamp(0.75rem,1vw,0.875rem)] text-center">
+      <div className="pb-8">
+        <Link href={routes.contact} className="inline-block rounded-full bg-white text-black px-6 py-3 text-sm font-semibold shadow hover:bg-neutral-200 transition">
+          Let’s Talk
+        </Link>
+      </div>
       <div className="max-w-6xl mx-auto flex flex-col md:flex-row justify-between items-center gap-4">
         <p>&copy; {new Date().getFullYear()} NPR Media. All rights reserved.</p>
         <div className="flex gap-4">

--- a/src/components/global/Header.tsx
+++ b/src/components/global/Header.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { motion } from 'framer-motion';
+import { routes } from '@/lib/routes';
 
 export default function StickyHeader() {
   const [scrolled, setScrolled] = useState(false);
@@ -43,7 +44,7 @@ export default function StickyHeader() {
           <Link href="/about" className="text-[clamp(0.75rem,1vw,0.875rem)] hover:text-blue-600 hover:scale-105 transition-transform">
             About
           </Link>
-          <Link href="/contact" className="text-[clamp(0.75rem,1vw,0.875rem)] hover:text-blue-600 hover:scale-105 transition-transform">
+          <Link href={routes.contact} className="text-[clamp(0.75rem,1vw,0.875rem)] hover:text-blue-600 hover:scale-105 transition-transform">
             Contact
           </Link>
           <Link href="/blog" className="text-[clamp(0.75rem,1vw,0.875rem)] hover:text-blue-600 hover:scale-105 transition-transform">

--- a/src/components/sections/FinalCTA.tsx
+++ b/src/components/sections/FinalCTA.tsx
@@ -1,3 +1,5 @@
+import { routes } from '@/lib/routes';
+
 export default function FinalCTA() {
   return (
     <section className="bg-neutral-950 text-white py-20 px-6 text-center">
@@ -5,7 +7,7 @@ export default function FinalCTA() {
       <p className="text-lg mb-6 max-w-2xl mx-auto">
         We craft websites that drive serious results. Book your strategy call today.
       </p>
-      <a href="/contact" className="inline-block bg-white text-black font-semibold py-3 px-6 rounded-lg hover:bg-neutral-200 transition">
+      <a href={routes.contact} className="inline-block bg-white text-black font-semibold py-3 px-6 rounded-lg hover:bg-neutral-200 transition">
         Book Free Discovery Call
       </a>
       <p className="text-sm mt-4 text-neutral-400">No pressure. Just clarity and next steps.</p>

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -1,0 +1,6 @@
+export const routes = {
+  home: '/',
+  about: '/about',
+  pricing: '/pricing',
+  contact: '/contact',
+};


### PR DESCRIPTION
## Summary
- add new `/contact` page with responsive form and alternate contact methods
- implement optional CMS copy support
- centralize site routes in `src/lib/routes.ts`
- update navigation, footers, and CTAs to use new route constant
- create placeholder dynamic landing pages

## Testing
- `npm run lint`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6862b6d3741883288217c17630e7b794