### PR TITLE
Add contact page and CTA routing

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,175 @@
+'use client'
+
+import StickyHeader from '@/components/global/Header'
+import FooterSection from '@/components/global/Footer'
+import { motion } from 'framer-motion'
+import { useEffect, useState } from 'react'
+import { Phone, Mail, Calendar } from 'lucide-react'
+
+export default function ContactPage() {
+  const [copy, setCopy] = useState({
+    headline: 'Get in Touch',
+    subtext: "Fill out the form and we'll get back within one business day."
+  })
+
+  useEffect(() => {
+    import('@/content/contact')
+      .then((mod) => {
+        if (mod.contactCopy) setCopy(mod.contactCopy)
+      })
+      .catch(() => {})
+  }, [])
+
+  const [form, setForm] = useState({ name: '', email: '', summary: '' })
+  const [errors, setErrors] = useState<{ name?: string; email?: string; summary?: string }>({})
+  const [loading, setLoading] = useState(false)
+  const [success, setSuccess] = useState(false)
+
+  const validate = () => {
+    const errs: { name?: string; email?: string; summary?: string } = {}
+    if (!form.name.trim()) errs.name = 'Full name is required.'
+    if (!form.email.trim()) errs.email = 'Email is required.'
+    else if (!/^\S+@\S+\.\S+$/.test(form.email)) errs.email = 'Enter a valid email.'
+    if (!form.summary.trim()) errs.summary = 'Project summary is required.'
+    setErrors(errs)
+    return Object.keys(errs).length === 0
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!validate()) return
+    setLoading(true)
+    try {
+      const res = await fetch('/api/contact', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form)
+      })
+      if (res.ok) {
+        setSuccess(true)
+        setForm({ name: '', email: '', summary: '' })
+      }
+    } catch (err) {
+      console.error(err)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <section>
+      <StickyHeader />
+      <main className="relative overflow-hidden bg-white text-black min-h-screen flex items-center px-6 lg:px-12">
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.6 }}
+          className="absolute inset-0 -z-10 pointer-events-none"
+        >
+          <motion.div
+            className="absolute left-1/2 top-0 h-96 w-96 -translate-x-1/2 rounded-full bg-pink-400/20 blur-3xl"
+            animate={{ y: [0, -50, 0] }}
+            transition={{ duration: 10, repeat: Infinity, ease: 'easeInOut' }}
+          />
+        </motion.div>
+
+        <div className="mx-auto w-full max-w-3xl space-y-8">
+          <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.1 }}>
+            <h1 className="text-4xl md:text-5xl font-bold text-center">{copy.headline}</h1>
+            <p className="mt-2 text-center text-neutral-600 dark:text-neutral-400">{copy.subtext}</p>
+          </motion.div>
+
+          {!success ? (
+            <motion.form
+              onSubmit={handleSubmit}
+              className="space-y-4 rounded-xl bg-white/80 p-6 shadow-md backdrop-blur-md dark:bg-neutral-900/80"
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.2 }}
+            >
+              <label className="block text-sm font-medium">
+                Full Name
+                <input
+                  type="text"
+                  value={form.name}
+                  onChange={(e) => setForm({ ...form, name: e.target.value })}
+                  className="mt-1 w-full rounded-md border border-neutral-300 bg-white px-3 py-2 text-black dark:bg-neutral-800 dark:text-white focus-visible:outline focus-visible:outline-blue-500"
+                />
+              </label>
+              {errors.name && <p className="text-xs text-red-500">{errors.name}</p>}
+
+              <label className="block text-sm font-medium">
+                Work Email
+                <input
+                  type="email"
+                  required
+                  value={form.email}
+                  onChange={(e) => setForm({ ...form, email: e.target.value })}
+                  className="mt-1 w-full rounded-md border border-neutral-300 bg-white px-3 py-2 text-black dark:bg-neutral-800 dark:text-white focus-visible:outline focus-visible:outline-blue-500"
+                />
+              </label>
+              {errors.email && <p className="text-xs text-red-500">{errors.email}</p>}
+
+              <label className="block text-sm font-medium">
+                Project Summary
+                <textarea
+                  rows={5}
+                  value={form.summary}
+                  onChange={(e) => setForm({ ...form, summary: e.target.value })}
+                  className="mt-1 w-full rounded-md border border-neutral-300 bg-white px-3 py-2 text-black dark:bg-neutral-800 dark:text-white focus-visible:outline focus-visible:outline-blue-500"
+                />
+              </label>
+              {errors.summary && <p className="text-xs text-red-500">{errors.summary}</p>}
+
+              <button
+                type="submit"
+                disabled={loading}
+                className="mt-2 w-full rounded-xl bg-black py-3 px-6 text-white shadow-lg transition hover:scale-105 focus-visible:outline focus-visible:outline-blue-500"
+              >
+                {loading ? 'Sending...' : 'Send Message'}
+              </button>
+              <p className="text-xs text-neutral-500 italic mt-2">We reply to every serious inquiry within 1 business day.</p>
+            </motion.form>
+          ) : (
+            <motion.div
+              className="rounded-xl bg-white/80 p-6 text-center shadow-md backdrop-blur-md dark:bg-neutral-900/80"
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.2 }}
+            >
+              <p className="text-lg font-semibold">Thank you! We&apos;ll be in touch soon.</p>
+            </motion.div>
+          )}
+
+          <motion.div
+            className="grid grid-cols-1 gap-4 sm:grid-cols-3"
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.3 }}
+          >
+            <div className="flex flex-col items-center rounded-lg bg-neutral-100 p-4 shadow dark:bg-neutral-800">
+              <Phone className="h-6 w-6 text-[var(--color-accent)]" />
+              <p className="mt-2 text-sm">+1 (555) 123-4567</p>
+            </div>
+            <div className="flex flex-col items-center rounded-lg bg-neutral-100 p-4 shadow dark:bg-neutral-800">
+              <Mail className="h-6 w-6 text-[var(--color-accent)]" />
+              <p className="mt-2 text-sm">contact@npr-media.com</p>
+            </div>
+            <div className="flex flex-col items-center rounded-lg bg-neutral-100 p-4 shadow dark:bg-neutral-800">
+              <Calendar className="h-6 w-6 text-[var(--color-accent)]" />
+              <a
+                href="https://calendly.com/your-link"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-2 text-sm underline-offset-4 hover:underline"
+              >
+                Book a Call
+              </a>
+            </div>
+          </motion.div>
+        </div>
+      </main>
+      <FooterSection />
+    </section>
+  )
+}

--- a/src/app/landing/[slug]/page.tsx
+++ b/src/app/landing/[slug]/page.tsx
@@ -1,0 +1,16 @@
+import { routes } from '@/lib/routes'
+
+export default function LandingPage() {
+  return (
+    <main className="min-h-screen flex flex-col items-center justify-center p-6 space-y-6">
+      <h1 className="text-3xl font-bold">Landing Page</h1>
+      <p className="text-lg">This is a placeholder landing page.</p>
+      <a
+        href={routes.contact}
+        className="inline-block rounded-lg bg-black px-6 py-3 text-white shadow transition hover:scale-105"
+      >
+        Contact Us
+      </a>
+    </main>
+  )
+}

--- a/src/app/why-npr/page.tsx
+++ b/src/app/why-npr/page.tsx
@@ -11,6 +11,7 @@ import FinalCTA from '@/components/sections/FinalCTA'
 import { motion, useInView } from 'framer-motion'
 import { useEffect, useRef, useState } from 'react'
 import { Ban, CheckCircle2 } from 'lucide-react'
+import { routes } from '@/lib/routes'
 
 function TypingText({ text }: { text: string }) {
   const ref = useRef<HTMLDivElement>(null)
@@ -246,7 +247,7 @@ export default function WhyNprPage() {
                 <p className="text-sm text-gray-500">The NPR no-bloat process</p>
                 <div className="pt-2">
                   <a
-                    href="/contact"
+                    href={routes.contact}
                     className="inline-block rounded-full bg-gradient-to-r from-[var(--color-accent)] to-[var(--color-accent-dark)] px-4 py-2 text-xs font-semibold text-white shadow transition hover:scale-105"
                   >
                     Start winning

--- a/src/components/global/Footer.tsx
+++ b/src/components/global/Footer.tsx
@@ -1,16 +1,31 @@
 'use client'
 
 import Link from 'next/link'
+import { routes } from '@/lib/routes'
 
 export default function Footer() {
   return (
-    <footer id="footer" className="bg-[var(--color-bg-dark)] text-[var(--color-text-light)] border-t px-[clamp(1rem,4vw,3rem)] py-[clamp(2.5rem,6vw,4rem)] text-[clamp(0.75rem,1vw,0.875rem)] text-center">
-      <div className="max-w-6xl mx-auto flex flex-col md:flex-row justify-between items-center gap-4">
-        <p>&copy; {new Date().getFullYear()} NPR Media. All rights reserved.</p>
-        <div className="flex gap-4">
-          <Link href="#">Privacy</Link>
-          <Link href="#">Terms</Link>
-          <Link href="mailto:hello@npr.media">Contact</Link>
+    <footer
+      id="footer"
+      className="bg-[var(--color-bg-dark)] text-[var(--color-text-light)] border-t px-[clamp(1rem,4vw,3rem)] py-[clamp(2.5rem,6vw,4rem)] text-[clamp(0.75rem,1vw,0.875rem)] text-center"
+    >
+      <div className="mx-auto max-w-6xl space-y-8">
+        <div className="space-y-4">
+          <h2 className="text-2xl font-semibold">Ready to start?</h2>
+          <Link
+            href={routes.contact}
+            className="inline-block rounded-lg bg-white px-6 py-3 text-sm font-semibold text-black shadow-md transition hover:scale-105"
+          >
+            Let’s Talk
+          </Link>
+        </div>
+        <div className="flex flex-col items-center justify-between gap-4 md:flex-row">
+          <p>&copy; {new Date().getFullYear()} NPR Media. All rights reserved.</p>
+          <div className="flex gap-4">
+            <Link href="#">Privacy</Link>
+            <Link href="#">Terms</Link>
+            <Link href="mailto:hello@npr.media">Contact</Link>
+          </div>
         </div>
       </div>
     </footer>

--- a/src/components/global/Header.tsx
+++ b/src/components/global/Header.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { motion } from 'framer-motion';
+import { routes } from '@/lib/routes';
 
 export default function StickyHeader() {
   const [scrolled, setScrolled] = useState(false);
@@ -43,7 +44,7 @@ export default function StickyHeader() {
           <Link href="/about" className="text-[clamp(0.75rem,1vw,0.875rem)] hover:text-blue-600 hover:scale-105 transition-transform">
             About
           </Link>
-          <Link href="/contact" className="text-[clamp(0.75rem,1vw,0.875rem)] hover:text-blue-600 hover:scale-105 transition-transform">
+          <Link href={routes.contact} className="text-[clamp(0.75rem,1vw,0.875rem)] hover:text-blue-600 hover:scale-105 transition-transform">
             Contact
           </Link>
           <Link href="/blog" className="text-[clamp(0.75rem,1vw,0.875rem)] hover:text-blue-600 hover:scale-105 transition-transform">

--- a/src/components/sections/FinalCTA.tsx
+++ b/src/components/sections/FinalCTA.tsx
@@ -1,3 +1,5 @@
+import { routes } from '@/lib/routes'
+
 export default function FinalCTA() {
   return (
     <section className="bg-neutral-950 text-white py-20 px-6 text-center">
@@ -5,7 +7,7 @@ export default function FinalCTA() {
       <p className="text-lg mb-6 max-w-2xl mx-auto">
         We craft websites that drive serious results. Book your strategy call today.
       </p>
-      <a href="/contact" className="inline-block bg-white text-black font-semibold py-3 px-6 rounded-lg hover:bg-neutral-200 transition">
+      <a href={routes.contact} className="inline-block bg-white text-black font-semibold py-3 px-6 rounded-lg hover:bg-neutral-200 transition">
         Book Free Discovery Call
       </a>
       <p className="text-sm mt-4 text-neutral-400">No pressure. Just clarity and next steps.</p>

--- a/src/content/contact.ts
+++ b/src/content/contact.ts
@@ -1,0 +1,9 @@
+export interface ContactCopy {
+  headline: string
+  subtext: string
+}
+
+export const contactCopy: ContactCopy = {
+  headline: 'Let\u2019s Build Something Great',
+  subtext: 'Tell us about your project. We\u2019ll respond within one business day.'
+}

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -1,0 +1,3 @@
+export const routes = {
+  contact: '/contact'
+}


### PR DESCRIPTION
## Summary
- build `/contact` page with responsive form and alt contact cards
- add CTA section to footer
- centralize contact path via `routes.ts`
- use route constants in nav, CTAs, and why-NPR page
- create placeholder landing page that links to contact

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6862b6d3741883288217c17630e7b794