### PR TITLE
Add contact page and route utilities

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,185 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import StickyHeader from '@/components/global/Header';
+import FooterSection from '@/components/global/Footer';
+import { Phone, Mail, CalendarDays } from 'lucide-react';
+import { motion } from 'framer-motion';
+
+const defaultCopy = {
+  headline: "Let's Connect",
+  subtext: "Tell us about your project and we'll reach out shortly.",
+};
+
+export default function ContactPage() {
+  const [form, setForm] = useState({ name: '', email: '', summary: '' });
+  const [errors, setErrors] = useState<{
+    name?: string;
+    email?: string;
+    summary?: string;
+    general?: string;
+  }>({});
+  const [loading, setLoading] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const [copy, setCopy] = useState(defaultCopy);
+
+  useEffect(() => {
+    import('@/content/contact')
+      .then((mod) => {
+        if (mod?.contactCopy) {
+          setCopy({ ...defaultCopy, ...mod.contactCopy });
+        }
+      })
+      .catch(() => {});
+  }, []);
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const newErrors: typeof errors = {};
+    if (!form.name.trim()) newErrors.name = 'Required';
+    if (!form.email.trim()) newErrors.email = 'Required';
+    else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email.trim()))
+      newErrors.email = 'Invalid email';
+    if (!form.summary.trim()) newErrors.summary = 'Required';
+    if (Object.keys(newErrors).length) {
+      setErrors(newErrors);
+      return;
+    }
+    setErrors({});
+    setLoading(true);
+    try {
+      const res = await fetch('/api/contact', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form),
+      });
+      if (!res.ok) throw new Error('Network');
+      setSuccess(true);
+      setForm({ name: '', email: '', summary: '' });
+    } catch {
+      setErrors({ general: 'Something went wrong. Please try again.' });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <section>
+      <StickyHeader />
+      <main
+        className="relative flex min-h-screen flex-col items-center bg-white text-black"
+        style={{ paddingTop: 'calc(var(--header-height) + 2rem)' }}
+      >
+        <div className="absolute inset-0 -z-10 flex items-start justify-center overflow-hidden">
+          <motion.div
+            className="h-96 w-96 rounded-full bg-pink-300 opacity-20 blur-3xl"
+            animate={{ scale: [1, 1.2, 1] }}
+            transition={{ duration: 8, repeat: Infinity }}
+          />
+        </div>
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6 }}
+          className="w-full max-w-3xl space-y-8 px-6 lg:px-12"
+        >
+          <div className="space-y-2 text-center">
+            <h1 className="text-4xl font-bold md:text-5xl">{copy.headline}</h1>
+            <p className="text-neutral-600 dark:text-neutral-400">{copy.subtext}</p>
+          </div>
+
+          <form
+            onSubmit={handleSubmit}
+            className="space-y-4 rounded-xl bg-white/90 p-6 shadow-md backdrop-blur"
+          >
+            <label className="block text-sm font-medium" htmlFor="name">
+              Full Name
+              <input
+                id="name"
+                type="text"
+                className="mt-1 w-full rounded border px-3 py-2 text-black focus-visible:outline focus-visible:outline-blue-500 dark:bg-neutral-800 dark:text-white"
+                value={form.name}
+                onChange={(e) => setForm({ ...form, name: e.target.value })}
+              />
+              {errors.name && (
+                <p className="mt-1 text-xs text-red-600" id="name-error">
+                  {errors.name}
+                </p>
+              )}
+            </label>
+            <label className="block text-sm font-medium" htmlFor="email">
+              Work Email
+              <input
+                id="email"
+                type="email"
+                required
+                className="mt-1 w-full rounded border px-3 py-2 text-black focus-visible:outline focus-visible:outline-blue-500 dark:bg-neutral-800 dark:text-white"
+                value={form.email}
+                onChange={(e) => setForm({ ...form, email: e.target.value })}
+                aria-describedby={errors.email ? 'email-error' : undefined}
+              />
+              {errors.email && (
+                <p className="mt-1 text-xs text-red-600" id="email-error">
+                  {errors.email}
+                </p>
+              )}
+            </label>
+            <label className="block text-sm font-medium" htmlFor="summary">
+              Project Summary
+              <textarea
+                id="summary"
+                rows={5}
+                className="mt-1 w-full rounded border px-3 py-2 text-black focus-visible:outline focus-visible:outline-blue-500 dark:bg-neutral-800 dark:text-white"
+                value={form.summary}
+                onChange={(e) => setForm({ ...form, summary: e.target.value })}
+              />
+              {errors.summary && (
+                <p className="mt-1 text-xs text-red-600" id="summary-error">
+                  {errors.summary}
+                </p>
+              )}
+            </label>
+            {errors.general && (
+              <p className="text-xs text-red-600" role="alert">
+                {errors.general}
+              </p>
+            )}
+            {success ? (
+              <p className="text-sm text-green-600">Thanks! We&apos;ll be in touch soon.</p>
+            ) : (
+              <button
+                type="submit"
+                className="w-full rounded-xl bg-black px-6 py-3 text-white shadow-lg transition hover:scale-105 disabled:opacity-50"
+                disabled={loading}
+              >
+                {loading ? <span className="animate-spin">⏳</span> : 'Send Message'}
+              </button>
+            )}
+            <p className="mt-2 text-xs text-neutral-500 italic">
+              We reply to every serious inquiry within 1 business day.
+            </p>
+          </form>
+
+          <div className="grid gap-4 pt-6 sm:grid-cols-3">
+            <div className="flex flex-col items-center rounded-lg border p-4 shadow-sm">
+              <Phone className="mb-2 h-5 w-5" />
+              <span className="text-sm">+1 (555) 123-4567</span>
+            </div>
+            <div className="flex flex-col items-center rounded-lg border p-4 shadow-sm">
+              <Mail className="mb-2 h-5 w-5" />
+              <span className="text-sm">contact@npr-media.com</span>
+            </div>
+            <a
+              href="https://calendly.com/placeholder"
+              className="flex flex-col items-center rounded-lg border p-4 shadow-sm hover:bg-neutral-50"
+            >
+              <CalendarDays className="mb-2 h-5 w-5" />
+              <span className="text-sm">Book a Call</span>
+            </a>
+          </div>
+        </motion.div>
+      </main>
+      <FooterSection />
+    </section>
+  );
+}

--- a/src/app/landing/[slug]/page.tsx
+++ b/src/app/landing/[slug]/page.tsx
@@ -1,0 +1,16 @@
+import { ROUTES } from '@/lib/routes';
+
+export default function LandingPage({ params }: { params: { slug: string } }) {
+  return (
+    <main className="mx-auto max-w-3xl space-y-6 px-6 py-20 text-center">
+      <h1 className="text-4xl font-bold">Landing: {params.slug}</h1>
+      <p className="text-neutral-600">This is a placeholder landing page.</p>
+      <a
+        href={ROUTES.contact}
+        className="inline-block rounded-xl bg-black px-6 py-3 text-white shadow-lg transition hover:scale-105"
+      >
+        Let’s Talk
+      </a>
+    </main>
+  );
+}

--- a/src/app/why-npr/page.tsx
+++ b/src/app/why-npr/page.tsx
@@ -1,34 +1,35 @@
-'use client'
+'use client';
 
-import StickyHeader from '@/components/global/Header'
-import FooterSection from '@/components/global/Footer'
-import ScrollCue from '@/components/global/ScrollCue'
-import WaveDivider from '@/components/whyNpr/WaveDivider'
-import AiCarousel from '@/components/whyNpr/AiCarousel'
-import NprCarousel from '@/components/whyNpr/NprCarousel'
-import FirmCarousel from '@/components/whyNpr/FirmCarousel'
-import FinalCTA from '@/components/sections/FinalCTA'
-import { motion, useInView } from 'framer-motion'
-import { useEffect, useRef, useState } from 'react'
-import { Ban, CheckCircle2 } from 'lucide-react'
+import StickyHeader from '@/components/global/Header';
+import FooterSection from '@/components/global/Footer';
+import ScrollCue from '@/components/global/ScrollCue';
+import WaveDivider from '@/components/whyNpr/WaveDivider';
+import AiCarousel from '@/components/whyNpr/AiCarousel';
+import NprCarousel from '@/components/whyNpr/NprCarousel';
+import FirmCarousel from '@/components/whyNpr/FirmCarousel';
+import FinalCTA from '@/components/sections/FinalCTA';
+import { motion, useInView } from 'framer-motion';
+import { useEffect, useRef, useState } from 'react';
+import { Ban, CheckCircle2 } from 'lucide-react';
+import { ROUTES } from '@/lib/routes';
 
 function TypingText({ text }: { text: string }) {
-  const ref = useRef<HTMLDivElement>(null)
-  const isInView = useInView(ref, { once: true })
-  const [display, setDisplay] = useState('')
+  const ref = useRef<HTMLDivElement>(null);
+  const isInView = useInView(ref, { once: true });
+  const [display, setDisplay] = useState('');
 
   useEffect(() => {
-    if (!isInView) return
-    let i = 0
+    if (!isInView) return;
+    let i = 0;
     const id = setInterval(() => {
-      i += 1
-      setDisplay(text.slice(0, i))
-      if (i >= text.length) clearInterval(id)
-    }, 40)
-    return () => clearInterval(id)
-  }, [isInView, text])
+      i += 1;
+      setDisplay(text.slice(0, i));
+      if (i >= text.length) clearInterval(id);
+    }, 40);
+    return () => clearInterval(id);
+  }, [isInView, text]);
 
-  return <div ref={ref}>{display}</div>
+  return <div ref={ref}>{display}</div>;
 }
 
 export default function WhyNprPage() {
@@ -36,28 +37,36 @@ export default function WhyNprPage() {
     <section>
       <StickyHeader />
       <main
-        className="relative w-full overflow-x-hidden bg-[var(--color-bg-dark)] text-[var(--color-text-light)] space-y-24"
+        className="relative w-full space-y-24 overflow-x-hidden bg-[var(--color-bg-dark)] text-[var(--color-text-light)]"
         style={{ paddingTop: 'calc(var(--header-height) + 1rem)' }}
       >
         {/* SECTION 1: NPR Media vs AI */}
         <section
           id="vs-ai"
-          className="relative overflow-hidden py-20 bg-[var(--color-bg-dark)] text-[var(--color-text-light)]"
+          className="relative overflow-hidden bg-[var(--color-bg-dark)] py-20 text-[var(--color-text-light)]"
         >
           <div className="pointer-events-none absolute inset-0 -z-10">
             <div className="absolute -top-10 left-1/2 h-96 w-96 -translate-x-1/2 rounded-full bg-gradient-to-br from-[var(--color-accent)] via-pink-500 to-[var(--color-accent-dark)] opacity-30 blur-3xl" />
           </div>
           <div className="container mx-auto max-w-6xl space-y-12 px-4">
-            <div className="text-center space-y-2">
-              <h1 className="text-[clamp(2rem,4vw,3rem)] font-bold tracking-tight">Why Human Strategy Beats AI Guesswork</h1>
-              <p className="text-[clamp(0.9rem,1.6vw,1.125rem)] text-gray-300">AI can parse data but it can&rsquo;t read minds or context.</p>
-              <p className="mx-auto max-w-xl text-sm text-gray-300">Our strategists apply lived experience and own the results from concept to launch.</p>
+            <div className="space-y-2 text-center">
+              <h1 className="text-[clamp(2rem,4vw,3rem)] font-bold tracking-tight">
+                Why Human Strategy Beats AI Guesswork
+              </h1>
+              <p className="text-[clamp(0.9rem,1.6vw,1.125rem)] text-gray-300">
+                AI can parse data but it can&rsquo;t read minds or context.
+              </p>
+              <p className="mx-auto max-w-xl text-sm text-gray-300">
+                Our strategists apply lived experience and own the results from concept to launch.
+              </p>
             </div>
             <div className="space-y-12">
               <div className="md:grid md:grid-cols-2 md:items-center md:gap-8">
-                <div className="pb-8 text-center md:pb-0 md:text-left space-y-2">
-                  <h2 className="text-3xl sm:text-4xl font-bold">What AI Can’t Do</h2>
-                  <p className="text-sm text-gray-300">Where automation simply can&rsquo;t compete</p>
+                <div className="space-y-2 pb-8 text-center md:pb-0 md:text-left">
+                  <h2 className="text-3xl font-bold sm:text-4xl">What AI Can’t Do</h2>
+                  <p className="text-sm text-gray-300">
+                    Where automation simply can&rsquo;t compete
+                  </p>
                   <div className="pt-2">
                     <a
                       href="/pricing"
@@ -78,13 +87,20 @@ export default function WhyNprPage() {
               </div>
               <div className="space-y-1 text-center">
                 <h2 className="text-xl font-bold text-gray-100">Here&rsquo;s where we step in</h2>
-                <p className="text-sm text-gray-400">Real humans refine the data and own the outcome.</p>
-                <ScrollCue href="#npr-delivers" className="mx-auto mt-2 text-[var(--color-accent)]" />
+                <p className="text-sm text-gray-400">
+                  Real humans refine the data and own the outcome.
+                </p>
+                <ScrollCue
+                  href="#npr-delivers"
+                  className="mx-auto mt-2 text-[var(--color-accent)]"
+                />
               </div>
               <div id="npr-delivers" className="md:grid md:grid-cols-2 md:items-center md:gap-8">
-                <div className="pb-8 text-center md:pb-0 md:text-left space-y-2">
-                  <h2 className="text-3xl sm:text-4xl font-bold">How NPR Media Delivers</h2>
-                  <p className="text-sm text-gray-300">Hands-on strategy that actually moves the needle</p>
+                <div className="space-y-2 pb-8 text-center md:pb-0 md:text-left">
+                  <h2 className="text-3xl font-bold sm:text-4xl">How NPR Media Delivers</h2>
+                  <p className="text-sm text-gray-300">
+                    Hands-on strategy that actually moves the needle
+                  </p>
                   <div className="pt-2">
                     <a
                       href="/pricing"
@@ -105,7 +121,8 @@ export default function WhyNprPage() {
               </div>
             </div>
             <p className="mx-auto mt-6 max-w-xl text-center text-sm text-gray-300">
-              Leaving growth to algorithms only repeats old mistakes. We build every campaign hands-on and measure success by your metrics.
+              Leaving growth to algorithms only repeats old mistakes. We build every campaign
+              hands-on and measure success by your metrics.
             </p>
             <hr className="my-16 h-px border-0 bg-gradient-to-r from-transparent via-white/50 to-transparent" />
             <div className="grid gap-6 md:grid-cols-2">
@@ -114,7 +131,7 @@ export default function WhyNprPage() {
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
                 transition={{ duration: 0.6 }}
-                className="rounded-xl bg-white/10 p-6 shadow-lg text-white"
+                className="rounded-xl bg-white/10 p-6 text-white shadow-lg"
               >
                 <p className="font-semibold">“Client X wouldn’t exist if we used AI.”</p>
               </motion.div>
@@ -123,18 +140,22 @@ export default function WhyNprPage() {
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
                 transition={{ duration: 0.6, delay: 0.1 }}
-                className="rounded-xl bg-white/10 p-6 shadow-lg text-white"
+                className="rounded-xl bg-white/10 p-6 text-white shadow-lg"
               >
-                <p className="font-semibold">“Our last launch doubled signups after a human-led overhaul.”</p>
+                <p className="font-semibold">
+                  “Our last launch doubled signups after a human-led overhaul.”
+                </p>
               </motion.div>
             </div>
-            <p className="mt-6 text-center text-sm text-gray-600">Skip the bloat and keep momentum with a senior crew measured on outcomes.</p>
+            <p className="mt-6 text-center text-sm text-gray-600">
+              Skip the bloat and keep momentum with a senior crew measured on outcomes.
+            </p>
             <hr className="my-16 h-px border-0 bg-gradient-to-r from-transparent via-white/50 to-transparent" />
             <motion.div
               initial={{ opacity: 0 }}
               whileInView={{ opacity: 1 }}
               viewport={{ once: true }}
-              className="relative mt-12 flex items-start justify-center rounded-xl bg-white/5 p-6 shadow-lg text-white md:p-8"
+              className="relative mt-12 flex items-start justify-center rounded-xl bg-white/5 p-6 text-white shadow-lg md:p-8"
             >
               <div className="w-1/2 pr-4 text-sm">
                 <p className="mb-2 font-semibold">AI output</p>
@@ -142,7 +163,7 @@ export default function WhyNprPage() {
                   <TypingText text="10 tips for SEO…" />
                 </div>
               </div>
-              <div className="absolute left-1/2 top-1/2 h-10 w-px -translate-y-1/2 transform bg-white/30" />
+              <div className="absolute top-1/2 left-1/2 h-10 w-px -translate-y-1/2 transform bg-white/30" />
               <div className="w-1/2 pl-4 text-sm">
                 <p className="mb-2 font-semibold">NPR Media approach</p>
                 <motion.div
@@ -150,7 +171,7 @@ export default function WhyNprPage() {
                   whileInView={{ opacity: 1, y: 0 }}
                   viewport={{ once: true }}
                   transition={{ duration: 0.6 }}
-                  className="rounded border border-white/30 bg-white/10 p-3 shadow-inner text-white"
+                  className="rounded border border-white/30 bg-white/10 p-3 text-white shadow-inner"
                 >
                   Bold hook → stat → CTA
                 </motion.div>
@@ -165,8 +186,8 @@ export default function WhyNprPage() {
               </a>
             </div>
             <p className="mt-10 text-center text-sm font-semibold text-gray-600">
-              AI isn&rsquo;t your only risk. Bloated agencies drain budgets and momentum.
-              Keep scrolling to see how our lean team drives faster wins.
+              AI isn&rsquo;t your only risk. Bloated agencies drain budgets and momentum. Keep
+              scrolling to see how our lean team drives faster wins.
             </p>
             <ScrollCue href="#vs-firms" className="mx-auto mt-4 text-[var(--color-accent)]" />
           </div>
@@ -174,19 +195,24 @@ export default function WhyNprPage() {
         <WaveDivider className="text-gray-100" />
 
         {/* SECTION 2: NPR Media vs Other Firms */}
-        <section
-          id="vs-firms"
-          className="relative overflow-hidden py-20 bg-white text-black"
-        >
+        <section id="vs-firms" className="relative overflow-hidden bg-white py-20 text-black">
           <div className="pointer-events-none absolute inset-0 -z-10">
-            <div className="absolute bottom-0 right-1/2 h-96 w-96 translate-x-1/2 rounded-full bg-gradient-to-br from-[var(--color-accent)] via-pink-400 to-[var(--color-accent-dark)] opacity-30 blur-3xl" />
+            <div className="absolute right-1/2 bottom-0 h-96 w-96 translate-x-1/2 rounded-full bg-gradient-to-br from-[var(--color-accent)] via-pink-400 to-[var(--color-accent-dark)] opacity-30 blur-3xl" />
           </div>
           <div className="container mx-auto max-w-6xl space-y-12 px-4">
             <div className="md:grid md:grid-cols-2 md:items-center md:gap-8">
-              <div className="text-center md:text-left space-y-4">
-                <h1 className="text-[clamp(2rem,4vw,3rem)] font-bold tracking-tight">Agency Bloat vs NPR Media</h1>
-                <p className="text-[clamp(0.9rem,1.6vw,1.125rem)] text-gray-600">AI tools won&rsquo;t own your numbers&mdash;and neither will bloated agencies. While others bill hours, we deliver outcomes.</p>
-                <p className="mx-auto max-w-xl text-sm text-gray-600 md:mx-0">Large firms pad projects with juniors and endless steps. Our senior strike team ships fast and stands behind every metric.</p>
+              <div className="space-y-4 text-center md:text-left">
+                <h1 className="text-[clamp(2rem,4vw,3rem)] font-bold tracking-tight">
+                  Agency Bloat vs NPR Media
+                </h1>
+                <p className="text-[clamp(0.9rem,1.6vw,1.125rem)] text-gray-600">
+                  AI tools won&rsquo;t own your numbers&mdash;and neither will bloated agencies.
+                  While others bill hours, we deliver outcomes.
+                </p>
+                <p className="mx-auto max-w-xl text-sm text-gray-600 md:mx-0">
+                  Large firms pad projects with juniors and endless steps. Our senior strike team
+                  ships fast and stands behind every metric.
+                </p>
               </div>
               <motion.div
                 initial={{ opacity: 0, y: 40 }}
@@ -197,14 +223,16 @@ export default function WhyNprPage() {
               </motion.div>
             </div>
             <hr className="my-16 h-px border-0 bg-gradient-to-r from-transparent via-gray-400 to-transparent" />
-            <p className="text-center text-sm font-semibold text-gray-500">Here&rsquo;s how we do it differently.</p>
+            <p className="text-center text-sm font-semibold text-gray-500">
+              Here&rsquo;s how we do it differently.
+            </p>
             <div className="grid gap-8 text-sm md:grid-cols-2">
               <motion.div
                 initial={{ opacity: 0, y: 20 }}
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
                 transition={{ duration: 0.6 }}
-                className="space-y-2 rounded-xl bg-white p-6 shadow-md text-gray-800"
+                className="space-y-2 rounded-xl bg-white p-6 text-gray-800 shadow-md"
               >
                 <p className="text-lg font-semibold">What other firms drag you through</p>
                 <p className="text-sm text-gray-500">Extras you don&rsquo;t actually need</p>
@@ -240,13 +268,13 @@ export default function WhyNprPage() {
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
                 transition={{ duration: 0.6, delay: 0.1 }}
-                className="space-y-2 rounded-xl bg-white p-6 shadow-md text-gray-800"
+                className="space-y-2 rounded-xl bg-white p-6 text-gray-800 shadow-md"
               >
                 <p className="text-lg font-semibold">How we keep projects moving</p>
                 <p className="text-sm text-gray-500">The NPR no-bloat process</p>
                 <div className="pt-2">
                   <a
-                    href="/contact"
+                    href={ROUTES.contact}
                     className="inline-block rounded-full bg-gradient-to-r from-[var(--color-accent)] to-[var(--color-accent-dark)] px-4 py-2 text-xs font-semibold text-white shadow transition hover:scale-105"
                   >
                     Start winning
@@ -276,7 +304,9 @@ export default function WhyNprPage() {
                 </ul>
               </motion.div>
             </div>
-            <p className="mt-8 text-center text-sm font-semibold italic">“94% of our clients switch from other firms—and never go back.”</p>
+            <p className="mt-8 text-center text-sm font-semibold italic">
+              “94% of our clients switch from other firms—and never go back.”
+            </p>
             <div className="pt-8 text-center">
               <a
                 href="/about"
@@ -293,5 +323,5 @@ export default function WhyNprPage() {
       <FinalCTA />
       <FooterSection />
     </section>
-  )
+  );
 }

--- a/src/components/global/Footer.tsx
+++ b/src/components/global/Footer.tsx
@@ -1,11 +1,23 @@
-'use client'
+'use client';
 
-import Link from 'next/link'
+import Link from 'next/link';
+import { ROUTES } from '@/lib/routes';
 
 export default function Footer() {
   return (
-    <footer id="footer" className="bg-[var(--color-bg-dark)] text-[var(--color-text-light)] border-t px-[clamp(1rem,4vw,3rem)] py-[clamp(2.5rem,6vw,4rem)] text-[clamp(0.75rem,1vw,0.875rem)] text-center">
-      <div className="max-w-6xl mx-auto flex flex-col md:flex-row justify-between items-center gap-4">
+    <footer
+      id="footer"
+      className="space-y-6 border-t bg-[var(--color-bg-dark)] px-[clamp(1rem,4vw,3rem)] py-[clamp(2.5rem,6vw,4rem)] text-center text-[clamp(0.75rem,1vw,0.875rem)] text-[var(--color-text-light)]"
+    >
+      <div>
+        <Link
+          href={ROUTES.contact}
+          className="inline-block rounded-lg bg-white px-6 py-3 font-semibold text-black shadow transition hover:scale-105"
+        >
+          Let’s Talk
+        </Link>
+      </div>
+      <div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-4 md:flex-row">
         <p>&copy; {new Date().getFullYear()} NPR Media. All rights reserved.</p>
         <div className="flex gap-4">
           <Link href="#">Privacy</Link>
@@ -14,5 +26,5 @@ export default function Footer() {
         </div>
       </div>
     </footer>
-  )
+  );
 }

--- a/src/components/global/Header.tsx
+++ b/src/components/global/Header.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { motion } from 'framer-motion';
+import { ROUTES } from '@/lib/routes';
 
 export default function StickyHeader() {
   const [scrolled, setScrolled] = useState(false);
@@ -20,41 +21,54 @@ export default function StickyHeader() {
       initial={{ y: -80, opacity: 0 }}
       animate={{ y: 0, opacity: 1 }}
       transition={{ duration: 0.6 }}
-      className={`fixed top-0 left-0 w-full z-50 transition-all ${
-        scrolled
-          ? 'bg-[#0A0F1C]/90 backdrop-blur-sm shadow-md'
-          : 'bg-transparent backdrop-blur-0'
+      className={`fixed top-0 left-0 z-50 w-full transition-all ${
+        scrolled ? 'bg-[#0A0F1C]/90 shadow-md backdrop-blur-sm' : 'backdrop-blur-0 bg-transparent'
       } text-[var(--color-text-light)]`}
     >
       <div
-        className="mx-auto flex h-[clamp(3rem,6vw,3.75rem)] w-full items-center justify-between px-3 md:px-10 lg:px-60 text-[var(--color-text-light)]"
+        className="mx-auto flex h-[clamp(3rem,6vw,3.75rem)] w-full items-center justify-between px-3 text-[var(--color-text-light)] md:px-10 lg:px-60"
         style={{ backgroundColor: scrolled ? 'var(--color-bg-dark)' : 'transparent' }}
       >
         <Link
           href="/"
-          className="text-[clamp(0.9rem,1.4vw,1.25rem)] font-bold tracking-tight hover:scale-105 transition-transform"
+          className="text-[clamp(0.9rem,1.4vw,1.25rem)] font-bold tracking-tight transition-transform hover:scale-105"
         >
           NPR MEDIA
         </Link>
-        <nav className="hidden md:flex gap-[clamp(1.25rem,3vw,2rem)] items-center">
-          <Link href="/pricing" className="text-[clamp(0.75rem,1vw,0.875rem)] hover:text-blue-600 hover:scale-105 transition-transform">
+        <nav className="hidden items-center gap-[clamp(1.25rem,3vw,2rem)] md:flex">
+          <Link
+            href="/pricing"
+            className="text-[clamp(0.75rem,1vw,0.875rem)] transition-transform hover:scale-105 hover:text-blue-600"
+          >
             Pricing
           </Link>
-          <Link href="/about" className="text-[clamp(0.75rem,1vw,0.875rem)] hover:text-blue-600 hover:scale-105 transition-transform">
+          <Link
+            href="/about"
+            className="text-[clamp(0.75rem,1vw,0.875rem)] transition-transform hover:scale-105 hover:text-blue-600"
+          >
             About
           </Link>
-          <Link href="/contact" className="text-[clamp(0.75rem,1vw,0.875rem)] hover:text-blue-600 hover:scale-105 transition-transform">
+          <Link
+            href={ROUTES.contact}
+            className="text-[clamp(0.75rem,1vw,0.875rem)] transition-transform hover:scale-105 hover:text-blue-600"
+          >
             Contact
           </Link>
-          <Link href="/blog" className="text-[clamp(0.75rem,1vw,0.875rem)] hover:text-blue-600 hover:scale-105 transition-transform">
+          <Link
+            href="/blog"
+            className="text-[clamp(0.75rem,1vw,0.875rem)] transition-transform hover:scale-105 hover:text-blue-600"
+          >
             Blog
           </Link>
-          <Link href="/why-npr" className="text-[clamp(0.75rem,1vw,0.875rem)] hover:text-blue-600 hover:scale-105 transition-transform">
+          <Link
+            href="/why-npr"
+            className="text-[clamp(0.75rem,1vw,0.875rem)] transition-transform hover:scale-105 hover:text-blue-600"
+          >
             Why NPR
           </Link>
           <Link
             href="/signup"
-            className="ml-4 inline-flex items-center gap-2 bg-black text-white px-4 py-[0.45rem] rounded-lg text-[clamp(0.65rem,0.9vw,0.75rem)] font-semibold shadow hover:brightness-110 hover:scale-105 transition-transform"
+            className="ml-4 inline-flex items-center gap-2 rounded-lg bg-black px-4 py-[0.45rem] text-[clamp(0.65rem,0.9vw,0.75rem)] font-semibold text-white shadow transition-transform hover:scale-105 hover:brightness-110"
           >
             Get Started →
           </Link>

--- a/src/components/sections/FinalCTA.tsx
+++ b/src/components/sections/FinalCTA.tsx
@@ -1,14 +1,19 @@
+import { ROUTES } from '@/lib/routes';
+
 export default function FinalCTA() {
   return (
-    <section className="bg-neutral-950 text-white py-20 px-6 text-center">
-      <h2 className="text-3xl md:text-4xl font-bold mb-4">Let’s build something legendary</h2>
-      <p className="text-lg mb-6 max-w-2xl mx-auto">
+    <section className="bg-neutral-950 px-6 py-20 text-center text-white">
+      <h2 className="mb-4 text-3xl font-bold md:text-4xl">Let’s build something legendary</h2>
+      <p className="mx-auto mb-6 max-w-2xl text-lg">
         We craft websites that drive serious results. Book your strategy call today.
       </p>
-      <a href="/contact" className="inline-block bg-white text-black font-semibold py-3 px-6 rounded-lg hover:bg-neutral-200 transition">
+      <a
+        href={ROUTES.contact}
+        className="inline-block rounded-lg bg-white px-6 py-3 font-semibold text-black transition hover:bg-neutral-200"
+      >
         Book Free Discovery Call
       </a>
-      <p className="text-sm mt-4 text-neutral-400">No pressure. Just clarity and next steps.</p>
+      <p className="mt-4 text-sm text-neutral-400">No pressure. Just clarity and next steps.</p>
     </section>
   );
 }

--- a/src/content/contact.ts
+++ b/src/content/contact.ts
@@ -1,0 +1,4 @@
+export const contactCopy = {
+  headline: "Let's Connect",
+  subtext: "Tell us about your project and we'll reach out shortly.",
+};

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -1,0 +1,3 @@
+export const ROUTES = {
+  contact: '/contact',
+};


### PR DESCRIPTION
## Summary
- create responsive contact page with form and alt contact methods
- centralize route constants and use for nav/footer/CTAs
- add footer CTA button
- add placeholder landing route using route constant
- update Why NPR and Final CTA sections to use route constant

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6862b6d3741883288217c17630e7b794