### PR TITLE
Add webdev landing page

### DIFF
--- a/src/app/webdev-landing/page.tsx
+++ b/src/app/webdev-landing/page.tsx
@@ -1,0 +1,51 @@
+'use client'
+import { useEffect, useState } from 'react'
+import Hero from '@/components/webdevLanding/Hero'
+import PainPoints from '@/components/webdevLanding/PainPoints'
+import OfferStack from '@/components/webdevLanding/OfferStack'
+import Proof from '@/components/webdevLanding/Proof'
+import PricingPreview from '@/components/webdevLanding/PricingPreview'
+import CTASection from '@/components/webdevLanding/CTASection'
+
+interface Content {
+  hero: { headline: string; subheadline: string; cta: string }
+}
+
+const defaultContent: Content = {
+  hero: {
+    headline: 'Web Development That Converts Cold Clicks Into Clients',
+    subheadline: 'We build elite, conversion-optimized sites for SaaS startups, DTC brands, and professional services firms.',
+    cta: 'Get a Free Strategy Mockup',
+  },
+}
+
+export default function WebdevLandingPage() {
+  const [content, setContent] = useState(defaultContent)
+
+  useEffect(() => {
+    async function loadContent() {
+      if (process.env.NEXT_PUBLIC_CMS === 'true') {
+        try {
+          const mod = await import('@/content/landing/webdev')
+          if (mod?.webdevLanding) {
+            setContent({ ...defaultContent, ...mod.webdevLanding })
+          }
+        } catch {
+          // ignore missing file
+        }
+      }
+    }
+    loadContent()
+  }, [])
+
+  return (
+    <main className="scroll-smooth scroll-snap-y-mandatory">
+      <Hero {...content.hero} />
+      <PainPoints />
+      <OfferStack />
+      <Proof />
+      <PricingPreview />
+      <CTASection />
+    </main>
+  )
+}

--- a/src/components/webdevLanding/CTASection.tsx
+++ b/src/components/webdevLanding/CTASection.tsx
@@ -1,0 +1,29 @@
+'use client'
+import { motion } from 'framer-motion'
+import MiniForm from './MiniForm'
+
+export default function CTASection() {
+  return (
+    <section id="cta" className="relative bg-gradient-to-br from-indigo-900 via-purple-800 to-blue-900 py-24 text-white">
+      <div className="mx-auto grid max-w-7xl grid-cols-1 gap-12 px-6 md:px-12 lg:px-20 md:grid-cols-2">
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.6 }}
+          className="space-y-4"
+        >
+          <h2 className="text-[clamp(2rem,5vw,3rem)] font-bold">Get Your Free Strategy Mockup</h2>
+          <p className="text-[clamp(1rem,2vw,1.25rem)]">Share your goals and we’ll map a high-converting website approach—free.</p>
+          <ul className="list-disc pl-5 text-sm marker:text-indigo-300">
+            <li>Actionable page-level insights</li>
+            <li>Senior dev & design expertise</li>
+            <li>100% obligation-free</li>
+          </ul>
+          <p className="text-sm text-indigo-200">Prefer to schedule a call? <a href="https://calendly.com" target="_blank" className="underline">Book via Calendly</a></p>
+        </motion.div>
+        <MiniForm />
+      </div>
+    </section>
+  )
+}

--- a/src/components/webdevLanding/Hero.tsx
+++ b/src/components/webdevLanding/Hero.tsx
@@ -1,0 +1,53 @@
+'use client'
+import { motion } from 'framer-motion'
+
+interface HeroProps {
+  headline: string
+  subheadline: string
+  cta: string
+}
+
+const textVariants = {
+  hidden: { opacity: 0, y: 20 },
+  visible: { opacity: 1, y: 0 }
+}
+
+export default function Hero({ headline, subheadline, cta }: HeroProps) {
+  return (
+    <section className="relative flex min-h-screen flex-col items-center justify-center overflow-hidden bg-gradient-to-br from-indigo-900 via-purple-800 to-blue-900 text-center text-white">
+      <motion.div
+        initial="hidden"
+        whileInView="visible"
+        viewport={{ once: true }}
+        variants={{ visible: { transition: { staggerChildren: 0.2 } } }}
+        className="mx-auto max-w-4xl px-6 md:px-12 lg:px-20"
+      >
+        <motion.h1
+          variants={textVariants}
+          className="text-[clamp(2.5rem,6vw,4rem)] font-bold"
+        >
+          {headline}
+        </motion.h1>
+        <motion.p
+          variants={textVariants}
+          className="mt-4 text-[clamp(1rem,2.2vw,1.5rem)]"
+        >
+          {subheadline}
+        </motion.p>
+        <motion.a
+          variants={textVariants}
+          href="#cta"
+          data-event="webdev-scroll-trigger"
+          className="mt-8 inline-block rounded-full bg-white px-6 py-3 font-semibold text-black shadow-lg ring-1 ring-white/10 transition hover:scale-105"
+        >
+          {cta}
+        </motion.a>
+      </motion.div>
+      <motion.div
+        className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_center,rgba(255,255,255,0.15),transparent_60%)]"
+        animate={{ scale: [1, 1.2, 1] }}
+        transition={{ duration: 10, repeat: Infinity }}
+      />
+    </section>
+  )
+}

--- a/src/components/webdevLanding/MiniForm.tsx
+++ b/src/components/webdevLanding/MiniForm.tsx
@@ -1,0 +1,75 @@
+'use client'
+import { useState } from 'react'
+import { motion } from 'framer-motion'
+import { User, Mail, DollarSign, MessageSquareText, Check } from 'lucide-react'
+
+export default function MiniForm() {
+  const [loading, setLoading] = useState(false)
+  const [success, setSuccess] = useState(false)
+  const [form, setForm] = useState({ name: '', email: '', budget: '', summary: '' })
+
+  const handleChange = (field: keyof typeof form) => (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
+    setForm({ ...form, [field]: e.target.value })
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setLoading(true)
+    await new Promise(res => setTimeout(res, 1200))
+    setLoading(false)
+    setSuccess(true)
+    setTimeout(() => setSuccess(false), 2500)
+  }
+
+  const baseInput = 'peer w-full rounded-md bg-white/80 px-10 py-3 text-sm text-black shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/40 placeholder-transparent'
+  const iconBase = 'absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-neutral-400 pointer-events-none'
+  const labelBase = 'pointer-events-none absolute left-10 top-1/2 -translate-y-1/2 text-sm text-neutral-500 transition-all peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2 peer-focus:top-2 peer-focus:-translate-y-0 peer-focus:text-xs'
+
+  return (
+    <motion.form
+      onSubmit={handleSubmit}
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+      transition={{ duration: 0.6, delay: 0.2 }}
+      className="space-y-4 rounded-2xl bg-white/20 p-6 shadow-xl ring-1 ring-white/10 backdrop-blur"
+    >
+      <div className="relative">
+        <User className={iconBase} />
+        <input id="name" type="text" value={form.name} onChange={handleChange('name')} placeholder=" " required className={baseInput} />
+        <label htmlFor="name" className={labelBase}>Full Name</label>
+      </div>
+      <div className="relative">
+        <Mail className={iconBase} />
+        <input id="email" type="email" value={form.email} onChange={handleChange('email')} placeholder=" " required className={baseInput} />
+        <label htmlFor="email" className={labelBase}>Work Email</label>
+      </div>
+      <div className="relative">
+        <DollarSign className={iconBase} />
+        <select id="budget" value={form.budget} onChange={handleChange('budget')} required className={`${baseInput} appearance-none pr-8`}> 
+          <option value="" disabled hidden />
+          <option value="<1k">{'<1k'}</option>
+          <option value="1k–5k">1k–5k</option>
+          <option value="5k–15k">5k–15k</option>
+          <option value="15k+">15k+</option>
+        </select>
+        <label htmlFor="budget" className={labelBase}>Budget</label>
+      </div>
+      <div className="relative">
+        <MessageSquareText className={iconBase} />
+        <textarea id="summary" rows={3} value={form.summary} onChange={handleChange('summary')} placeholder=" " required className={`${baseInput} resize-none`} />
+        <label htmlFor="summary" className={labelBase}>Project Summary</label>
+      </div>
+      <motion.button
+        type="submit"
+        data-event="webdev-cta-submit"
+        whileHover={{ scale: !loading && !success ? 1.05 : 1 }}
+        disabled={loading || success}
+        className="relative flex w-full items-center justify-center gap-2 rounded-xl bg-indigo-600 py-3 font-semibold text-white shadow-md transition"
+      >
+        {loading ? <span className="h-5 w-5 animate-spin rounded-full border-2 border-white border-t-transparent" /> : success ? <Check className="h-5 w-5" /> : 'Start My Mockup'}
+      </motion.button>
+      {success && <p className="pt-2 text-center text-sm text-indigo-200">We’ll be in touch shortly.</p>}
+    </motion.form>
+  )
+}

--- a/src/components/webdevLanding/OfferStack.tsx
+++ b/src/components/webdevLanding/OfferStack.tsx
@@ -1,0 +1,45 @@
+'use client'
+import { motion } from 'framer-motion'
+import { Code, Smartphone, LayoutDashboard, Rocket, Database } from 'lucide-react'
+
+const items = [
+  { icon: Code, label: 'Custom-coded frontend', text: 'Next.js + Tailwind for blazing speed' },
+  { icon: Smartphone, label: 'Mobile-first design', text: 'Optimized UX across all devices' },
+  { icon: LayoutDashboard, label: 'Strategy-backed layouts', text: 'Built to convert, not just look good' },
+  { icon: Database, label: 'CMS integration', text: 'Easily manage content at scale' },
+  { icon: Rocket, label: 'Fast turnaround', text: 'Launch weeks faster than typical shops' },
+]
+
+export default function OfferStack() {
+  return (
+    <section className="bg-neutral-100 py-24">
+      <div className="mx-auto max-w-7xl px-6 md:px-12 lg:px-20">
+        <motion.h2
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.6 }}
+          className="text-center text-[clamp(2rem,5vw,3rem)] font-bold"
+        >
+          What You’ll Get With NPR Media
+        </motion.h2>
+        <div className="mt-12 grid gap-8 md:grid-cols-5">
+          {items.map((item, i) => (
+            <motion.div
+              key={item.label}
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ duration: 0.5, delay: i * 0.1 }}
+              className="rounded-2xl bg-white/70 p-6 text-center shadow-xl ring-1 ring-black/10 backdrop-blur-md hover:shadow-2xl"
+            >
+              <item.icon className="mx-auto mb-3 h-6 w-6 text-indigo-600" />
+              <h3 className="mb-1 font-semibold text-[clamp(1rem,1.6vw,1.25rem)]">{item.label}</h3>
+              <p className="text-sm text-neutral-700">{item.text}</p>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/webdevLanding/PainPoints.tsx
+++ b/src/components/webdevLanding/PainPoints.tsx
@@ -1,0 +1,49 @@
+'use client'
+import { motion } from 'framer-motion'
+import { AlertTriangle, Clock, Ban } from 'lucide-react'
+
+interface Point {
+  icon: React.ReactNode
+  title: string
+  text: string
+}
+
+const points: Point[] = [
+  { icon: <AlertTriangle className="h-6 w-6" />, title: 'They Miss the Strategy', text: 'Most devs jump straight to code without understanding conversions.' },
+  { icon: <Clock className="h-6 w-6" />, title: 'Slow and Overpriced', text: 'Bloated teams pad timelines and budgets.' },
+  { icon: <Ban className="h-6 w-6" />, title: 'Not Built to Convert', text: 'Pretty sites that forget UX and revenue.' },
+]
+
+export default function PainPoints() {
+  return (
+    <section className="mx-auto max-w-7xl px-6 md:px-12 lg:px-20 py-24">
+      <motion.h2
+        initial={{ opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.6 }}
+        className="text-center text-[clamp(2rem,5vw,3rem)] font-bold"
+      >
+        The Problem With Most Web Dev Agencies…
+      </motion.h2>
+      <div className="mt-12 grid gap-8 md:grid-cols-3">
+        {points.map((p, i) => (
+          <motion.div
+            key={p.title}
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.5, delay: i * 0.1 }}
+            className="rounded-2xl bg-white/60 p-6 text-center shadow-xl ring-1 ring-black/10 backdrop-blur-md hover:shadow-2xl"
+          >
+            <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-indigo-500/20 text-indigo-400">
+              {p.icon}
+            </div>
+            <h3 className="mb-2 font-semibold text-[clamp(1.1rem,1.8vw,1.25rem)]">{p.title}</h3>
+            <p className="text-sm text-neutral-700">{p.text}</p>
+          </motion.div>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/components/webdevLanding/PricingPreview.tsx
+++ b/src/components/webdevLanding/PricingPreview.tsx
@@ -1,0 +1,49 @@
+'use client'
+import { motion } from 'framer-motion'
+
+export default function PricingPreview() {
+  return (
+    <section className="py-24">
+      <div className="mx-auto max-w-7xl px-6 md:px-12 lg:px-20 text-center">
+        <motion.h2
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.6 }}
+          className="text-[clamp(2rem,5vw,3rem)] font-bold"
+        >
+          Simple Pricing, No Surprises
+        </motion.h2>
+        <motion.p
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.6, delay: 0.1 }}
+          className="mx-auto mt-4 max-w-2xl text-[clamp(1rem,2vw,1.25rem)]"
+        >
+          Projects start at $1,000. Scope defines final cost — no retainers, no upsells.
+        </motion.p>
+        <motion.a
+          href="#cta"
+          data-event="webdev-scroll-trigger"
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.6, delay: 0.2 }}
+          className="mt-8 inline-block rounded-full bg-indigo-600 px-6 py-3 font-semibold text-white shadow-lg transition hover:scale-105"
+        >
+          Let’s Build Your Quote
+        </motion.a>
+        <motion.p
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.6, delay: 0.3 }}
+          className="mt-4 text-sm text-neutral-600"
+        >
+          We respond to every serious request within 1 business day.
+        </motion.p>
+      </div>
+    </section>
+  )
+}

--- a/src/components/webdevLanding/Proof.tsx
+++ b/src/components/webdevLanding/Proof.tsx
@@ -1,0 +1,54 @@
+'use client'
+import { motion } from 'framer-motion'
+
+const testimonials = [
+  {
+    quote: 'NPR Media delivered a polished site that doubled our demo sign-ups.',
+    name: 'Sarah K.',
+    title: 'SaaS Founder',
+  },
+  {
+    quote: 'Our new DTC store went from zero to profitable in weeks.',
+    name: 'Mike L.',
+    title: 'Ecommerce Owner',
+  },
+  {
+    quote: 'Fast, strategic, and conversion-focused. Exactly what we needed.',
+    name: 'Ana R.',
+    title: 'Marketing Director',
+  },
+]
+
+export default function Proof() {
+  return (
+    <section className="py-24">
+      <div className="mx-auto max-w-7xl px-6 md:px-12 lg:px-20">
+        <motion.h2
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.6 }}
+          className="text-center text-[clamp(2rem,5vw,3rem)] font-bold"
+        >
+          Trusted by Founders Across Industries
+        </motion.h2>
+        <div className="mt-12 grid gap-8 md:grid-cols-3">
+          {testimonials.map((t, i) => (
+            <motion.div
+              key={i}
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ duration: 0.5, delay: i * 0.1 }}
+              className="rounded-2xl bg-white/70 p-6 shadow-xl ring-1 ring-black/10 backdrop-blur-md hover:shadow-2xl"
+            >
+              <p className="text-sm italic">&ldquo;{t.quote}&rdquo;</p>
+              <p className="mt-4 font-semibold">{t.name}</p>
+              <p className="text-xs text-neutral-500">{t.title}</p>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/content/landing/webdev.ts
+++ b/src/content/landing/webdev.ts
@@ -1,0 +1,8 @@
+export const webdevLanding = {
+  hero: {
+    headline: 'Web Development That Converts Cold Clicks Into Clients',
+    subheadline: 'We build elite, conversion-optimized sites for SaaS startups, DTC brands, and professional services firms.',
+    cta: 'Get a Free Strategy Mockup',
+  },
+}
+export default webdevLanding


### PR DESCRIPTION
## Summary
- create webdev landing page with CMS override
- add Hero, PainPoints, OfferStack, Proof, PricingPreview, CTASection components
- include MiniForm for final CTA
- seed optional landing content

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68633ba3e86483288dd1ada9628d09aa