### PR TITLE
Update CTA routing

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -5,6 +5,7 @@ import FooterSection from '@/components/global/Footer'
 import ValuesCarousel from '@/components/about/ValuesCarousel'
 import { motion } from 'framer-motion'
 import Image from 'next/image'
+import CTAButton from '@/components/CTAButton'
 
 export default function AboutPage() {
   return (
@@ -34,12 +35,13 @@ export default function AboutPage() {
               <h2 className="text-3xl sm:text-4xl font-bold">Values, Culture & Beliefs</h2>
               <p className="text-sm text-gray-600">Principles that guide every build</p>
               <div className="pt-2">
-                <a
-                  href="/pricing"
+                <CTAButton
+                  href="/webdev-landing"
+                  event="cta-about-values"
                   className="inline-block rounded-full bg-gradient-to-r from-[var(--color-accent)] to-[var(--color-accent-dark)] px-4 py-2 text-xs font-normal text-white shadow transition hover:scale-105"
                 >
                   Work with us
-                </a>
+                </CTAButton>
               </div>
             </div>
             <motion.div
@@ -120,9 +122,13 @@ export default function AboutPage() {
           <h2 className="text-2xl font-bold">Ready to accelerate?</h2>
           <p className="mx-auto mt-2 max-w-xl text-sm text-gray-300">Let&rsquo;s craft a website that scales with you. See how our process works.</p>
           <div className="pt-6">
-            <a href="/pricing" className="inline-block rounded-full bg-[var(--color-accent)] px-6 py-3 text-sm font-normal text-white shadow-md transition hover:scale-105 hover:bg-[var(--color-accent-dark)]">
-              View Pricing
-            </a>
+            <CTAButton
+              href="/webdev-landing"
+              event="cta-about-final"
+              className="inline-block rounded-full bg-[var(--color-accent)] px-6 py-3 text-sm font-normal text-white shadow-md transition hover:scale-105 hover:bg-[var(--color-accent-dark)]"
+            >
+              See Our Process
+            </CTAButton>
           </div>
         </section>
       </main>

--- a/src/app/why-npr/page.tsx
+++ b/src/app/why-npr/page.tsx
@@ -69,7 +69,8 @@ export default function WhyNprPage() {
                   </p>
                   <div className="pt-2">
                     <a
-                      href="/pricing"
+                      href="/webdev-landing"
+                      data-event="cta-social-proof"
                       className="inline-block rounded-full bg-gradient-to-r from-[var(--color-accent)] to-[var(--color-accent-dark)] px-4 py-2 text-xs font-semibold text-white shadow transition hover:scale-105"
                     >
                       See the difference
@@ -103,7 +104,8 @@ export default function WhyNprPage() {
                   </p>
                   <div className="pt-2">
                     <a
-                      href="/pricing"
+                      href="/webdev-landing"
+                      data-event="cta-social-proof"
                       className="inline-block rounded-full bg-gradient-to-r from-[var(--color-accent)] to-[var(--color-accent-dark)] px-4 py-2 text-xs font-semibold text-white shadow transition hover:scale-105"
                     >
                       Explore our approach
@@ -179,7 +181,8 @@ export default function WhyNprPage() {
             </motion.div>
             <div className="pt-8 text-center">
               <a
-                href="/pricing"
+                href="/webdev-landing"
+                data-event="cta-social-proof"
                 className="inline-block rounded-full bg-gradient-to-r from-[var(--color-accent)] to-[var(--color-accent-dark)] px-6 py-3 text-sm font-semibold text-white shadow-md ring-1 ring-white/10 transition hover:scale-105"
               >
                 Don’t get AI’d. Get outcomes.
@@ -238,7 +241,8 @@ export default function WhyNprPage() {
                 <p className="text-sm text-gray-500">Extras you don&rsquo;t actually need</p>
                 <div className="pt-2">
                   <a
-                    href="/about"
+                    href="/webdev-landing"
+                    data-event="cta-social-proof"
                     className="inline-block rounded-full bg-gradient-to-r from-[var(--color-accent)] to-[var(--color-accent-dark)] px-4 py-2 text-xs font-semibold text-white shadow transition hover:scale-105"
                   >
                     Break free
@@ -275,6 +279,7 @@ export default function WhyNprPage() {
                 <div className="pt-2">
                   <a
                     href={Routes.contact}
+                    data-event="cta-service"
                     className="inline-block rounded-full bg-gradient-to-r from-[var(--color-accent)] to-[var(--color-accent-dark)] px-4 py-2 text-xs font-semibold text-white shadow transition hover:scale-105"
                   >
                     Start winning
@@ -309,7 +314,8 @@ export default function WhyNprPage() {
             </p>
             <div className="pt-8 text-center">
               <a
-                href="/about"
+                href="/webdev-landing"
+                data-event="cta-social-proof"
                 className="inline-block rounded-full bg-gradient-to-r from-[var(--color-accent)] to-[var(--color-accent-dark)] px-6 py-3 text-sm font-semibold text-white shadow-md ring-1 ring-black/10 transition hover:scale-105"
               >
                 This time, don’t settle.

--- a/src/components/CTAButton.tsx
+++ b/src/components/CTAButton.tsx
@@ -1,0 +1,17 @@
+import Link from 'next/link';
+import type { ReactNode } from 'react';
+
+interface CTAButtonProps {
+  href: string;
+  children: ReactNode;
+  event?: string;
+  className?: string;
+}
+
+export default function CTAButton({ href, children, event, className = 'inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-sm font-semibold text-black shadow-md transition hover:scale-105' }: CTAButtonProps) {
+  return (
+    <Link href={href} data-event={event} className={className}>
+      {children}
+    </Link>
+  );
+}

--- a/src/components/global/Footer.tsx
+++ b/src/components/global/Footer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { Routes } from '@/lib/routes';
+import CTAButton from '../CTAButton';
 
 export default function Footer() {
   return (
@@ -12,19 +12,20 @@ export default function Footer() {
       <div className="mx-auto max-w-6xl space-y-8">
         <div className="space-y-4">
           <p className="text-lg font-semibold">Ready to discuss your project?</p>
-          <Link
-            href={Routes.contact}
+          <CTAButton
+            href="/webdev-landing"
+            event="cta-footer-get-started"
             className="inline-block rounded-full bg-white px-6 py-3 text-sm font-semibold text-black shadow-md transition hover:scale-105"
           >
-            Let&rsquo;s Talk
-          </Link>
+            Get Started
+          </CTAButton>
         </div>
         <div className="flex flex-col items-center justify-between gap-4 md:flex-row">
           <p>&copy; {new Date().getFullYear()} NPR Media. All rights reserved.</p>
           <div className="flex gap-4">
             <Link href="#">Privacy</Link>
             <Link href="#">Terms</Link>
-            <Link href="mailto:hello@npr.media">Contact</Link>
+            <Link href="/contact" data-event="cta-footer-contact">Contact</Link>
           </div>
         </div>
       </div>

--- a/src/components/global/Header.tsx
+++ b/src/components/global/Header.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { motion } from 'framer-motion';
 import { Routes } from '@/lib/routes';
+import CTAButton from '../CTAButton';
 
 interface HeaderProps {
   /**
@@ -76,12 +77,13 @@ export default function StickyHeader({ light = false }: HeaderProps) {
           >
             Why NPR
           </Link>
-          <Link
-            href="/signup"
+          <CTAButton
+            href="/webdev-landing"
+            event="cta-navbar"
             className="ml-4 inline-flex items-center gap-2 rounded-lg bg-black px-4 py-[0.45rem] text-[clamp(0.65rem,0.9vw,0.75rem)] font-semibold text-white shadow transition-transform hover:scale-105 hover:brightness-110"
           >
             Get Started →
-          </Link>
+          </CTAButton>
         </nav>
       </div>
     </motion.header>

--- a/src/components/homepage/ContactSection.tsx
+++ b/src/components/homepage/ContactSection.tsx
@@ -22,6 +22,7 @@ export default function ContactSection() {
         <div className="pt-4">
           <Link
             href={cta.href}
+            data-event="cta-final"
             className="inline-flex items-center justify-center gap-2 rounded-full bg-white px-[clamp(1.25rem,3vw,1.5rem)] py-[clamp(0.6rem,1.2vw,0.75rem)] text-[clamp(0.8rem,1vw,0.9rem)] font-semibold text-black shadow-lg transition hover:scale-105 hover:shadow-xl"
           >
             {cta.label}

--- a/src/components/homepage/Hero.tsx
+++ b/src/components/homepage/Hero.tsx
@@ -164,6 +164,7 @@ const HeroSection: React.FC<HeroProps> = ({ headline, subheadline, ctaText, ctaL
               <Link
                 ref={ctaRef}
                 href={ctaLink}
+                data-event="cta-hero"
                 className="inline-flex items-center justify-center rounded-full px-4 py-[0.4rem] text-[clamp(0.7rem,1vw,0.9rem)] font-semibold text-black shadow-lg ring-1 bg-primary transition"
               >
                 {ctaText}

--- a/src/components/homepage/PricingSection.tsx
+++ b/src/components/homepage/PricingSection.tsx
@@ -3,6 +3,7 @@
 import { pricing } from '@/content/homepage/pricing'
 import QuoteModal from './QuoteModal'
 import { motion } from 'framer-motion'
+import Link from 'next/link'
 
 export default function PricingSection() {
   return (
@@ -69,9 +70,13 @@ export default function PricingSection() {
                 ))}
               </ul>
               <div className="pt-4">
-                <button className="w-full rounded-full border border-[var(--color-gray-600)] bg-[var(--color-bg-dark)] px-[clamp(1rem,2.5vw,1.25rem)] py-[clamp(0.6rem,1.2vw,0.75rem)] text-[clamp(0.8rem,1vw,0.9rem)] font-medium text-[var(--color-text-light)] shadow-sm transition hover:scale-105 hover:bg-[var(--color-gray-700)]">
+                <Link
+                  href="/contact"
+                  data-event="cta-pricing"
+                  className="block w-full rounded-full border border-[var(--color-gray-600)] bg-[var(--color-bg-dark)] px-[clamp(1rem,2.5vw,1.25rem)] py-[clamp(0.6rem,1.2vw,0.75rem)] text-center text-[clamp(0.8rem,1vw,0.9rem)] font-medium text-[var(--color-text-light)] shadow-sm transition hover:scale-105 hover:bg-[var(--color-gray-700)]"
+                >
                   {tier.cta}
-                </button>
+                </Link>
               </div>
             </motion.div>
           ))}

--- a/src/components/sections/FinalCTA.tsx
+++ b/src/components/sections/FinalCTA.tsx
@@ -9,6 +9,7 @@ export default function FinalCTA() {
       </p>
       <a
         href={Routes.contact}
+        data-event="cta-final"
         className="inline-block rounded-lg bg-white px-6 py-3 font-semibold text-black transition hover:bg-neutral-200"
       >
         Book Free Discovery Call

--- a/src/content/homepage/contactSection.ts
+++ b/src/content/homepage/contactSection.ts
@@ -3,8 +3,8 @@ export const contactSection = {
   subtitle:
     'Backed by proven UX strategy, real conversions, and startup-tested code. See why 50+ founders trust us.',
   cta: {
-    label: 'Book Your Free Strategy Call',
-    href: '#booking',
+    label: 'Let\'s Talk',
+    href: '/contact',
   },
   trust: 'No obligation. Just real insights.',
   urgency: 'Currently booking June projects',

--- a/src/content/homepage/hero.ts
+++ b/src/content/homepage/hero.ts
@@ -16,7 +16,7 @@ export interface HeroProps {
 export const hero: HeroProps = {
   headline: 'Automate Reporting. Save 12+ Hours Weekly.',
   subheadline: 'Built for SaaS teams who want cleaner dashboards and less spreadsheet chaos. Try it free — no card required.',
-  ctaText: 'Get started today',
-  ctaLink: '/signup',
+  ctaText: 'Get Started',
+  ctaLink: '/webdev-landing',
   // Preview image removed to avoid bundling binary assets
 };


### PR DESCRIPTION
## Summary
- add generic CTAButton component
- update hero and contact sections with new routes and analytics data
- rework pricing card buttons to go to `/contact`
- change navbar and footer CTAs to use new component
- adjust about and why-npr pages with intent-based links

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6864039bf0a883289b0e796f20f03ef4