### PR TITLE
Refactor site colors to custom earthy palette

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -20,20 +20,20 @@ export default function AboutPage() {
           className="bg-[var(--color-bg-dark)] text-[var(--color-text-light)] py-[clamp(5rem,10vw,8rem)] px-4 text-center"
         >
           <h1 className="text-[clamp(2rem,4vw,3rem)] font-bold">About NPR Media</h1>
-          <p className="mx-auto mt-4 max-w-2xl text-[clamp(0.9rem,1.6vw,1.125rem)] text-gray-300">
+          <p className="mx-auto mt-4 max-w-2xl text-[clamp(0.9rem,1.6vw,1.125rem)] text-silver">
             We craft high-performing websites and systems that help founders and startups scale faster.
           </p>
         </section>
 
         {/* Values */}
-        <section className="relative overflow-hidden py-20 bg-white text-black">
+        <section className="relative overflow-hidden py-20 bg-antique text-charcoal">
           <div className="pointer-events-none absolute inset-0 -z-10">
-            <div className="absolute -top-10 left-1/2 h-96 w-96 -translate-x-1/2 rounded-full bg-gradient-to-br from-[var(--color-accent)] via-pink-300 to-[var(--color-accent-dark)] opacity-20 blur-3xl" />
+            <div className="absolute -top-10 left-1/2 h-96 w-96 -translate-x-1/2 rounded-full bg-gradient-to-br from-[var(--color-accent)] via-blood to-[var(--color-accent-dark)] opacity-20 blur-3xl" />
           </div>
           <div className="container mx-auto max-w-6xl px-4 md:grid md:grid-cols-2 md:items-center md:gap-8">
             <div className="pb-8 text-center md:pb-0 md:text-left space-y-2">
               <h2 className="text-3xl sm:text-4xl font-bold">Values, Culture & Beliefs</h2>
-              <p className="text-sm text-gray-600">Principles that guide every build</p>
+              <p className="text-sm text-sepia">Principles that guide every build</p>
               <div className="pt-2">
                 <CTAButton
                   href="/webdev-landing"
@@ -60,21 +60,21 @@ export default function AboutPage() {
           <div className="mx-auto grid max-w-4xl gap-8 md:grid-cols-3 text-center">
             <div className="space-y-2">
               <h3 className="text-xl font-bold">Strategy First</h3>
-              <p className="text-sm text-gray-400">Every build starts with clear goals so your site drives real revenue.</p>
+              <p className="text-sm text-sepia">Every build starts with clear goals so your site drives real revenue.</p>
             </div>
             <div className="space-y-2">
               <h3 className="text-xl font-bold">Senior Expertise</h3>
-              <p className="text-sm text-gray-400">A compact team of vets ships faster than bloated agencies.</p>
+              <p className="text-sm text-sepia">A compact team of vets ships faster than bloated agencies.</p>
             </div>
             <div className="space-y-2">
               <h3 className="text-xl font-bold">Proven Results</h3>
-              <p className="text-sm text-gray-400">From SaaS dashboards to marketing sites, our work converts.</p>
+              <p className="text-sm text-sepia">From SaaS dashboards to marketing sites, our work converts.</p>
             </div>
           </div>
         </section>
 
         {/* Team */}
-        <section className="relative bg-white text-black py-[clamp(4rem,8vw,6rem)] px-4">
+        <section className="relative bg-antique text-charcoal py-[clamp(4rem,8vw,6rem)] px-4">
           <div className="pointer-events-none absolute inset-0 z-0 grid grid-cols-3 gap-0">
             <div
               className="h-full w-full bg-cover bg-center"
@@ -111,7 +111,7 @@ export default function AboutPage() {
                   className="mx-auto h-64 w-48 rounded-md object-cover shadow-2xl shadow-black/40"
                 />
                 <p className="font-normal">Taylor</p>
-                <p className="text-sm text-gray-600">Founder & CEO</p>
+                <p className="text-sm text-sepia">Founder & CEO</p>
               </div>
             </div>
           </div>
@@ -120,7 +120,7 @@ export default function AboutPage() {
         {/* CTA */}
         <section className="bg-[var(--color-bg-dark)] text-[var(--color-text-light)] py-[clamp(4rem,8vw,6rem)] px-4 text-center">
           <h2 className="text-2xl font-bold">Ready to accelerate?</h2>
-          <p className="mx-auto mt-2 max-w-xl text-sm text-gray-300">Let&rsquo;s craft a website that scales with you. See how our process works.</p>
+          <p className="mx-auto mt-2 max-w-xl text-sm text-silver">Let&rsquo;s craft a website that scales with you. See how our process works.</p>
           <div className="pt-6">
             <CTAButton
               href="/webdev-landing"

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -44,7 +44,7 @@ export default function ContactPage() {
         <div className="relative mx-auto w-full max-w-3xl space-y-8">
           <div className="pointer-events-none absolute inset-0 -z-10">
             <motion.div
-              className="h-72 w-72 rounded-full bg-blue-300/30 blur-3xl"
+              className="h-72 w-72 rounded-full bg-blood/30 blur-3xl"
               animate={{ opacity: [0.5, 1, 0.5], scale: [0.9, 1.1, 0.9] }}
               transition={{ duration: 8, repeat: Infinity }}
             />
@@ -55,7 +55,7 @@ export default function ContactPage() {
             transition={{ duration: 0.6 }}
           >
             <h1 className="text-4xl font-bold md:text-5xl">{copy.headline}</h1>
-            <p className="mt-2 text-neutral-600 dark:text-neutral-400">{copy.subtext}</p>
+            <p className="mt-2 text-charcoal">{copy.subtext}</p>
           </motion.div>
           <ContactForm />
           <StickyCTA />
@@ -65,15 +65,15 @@ export default function ContactPage() {
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.6, delay: 0.2 }}
           >
-            <div className="flex flex-col items-center rounded-xl bg-white/80 p-4 shadow-md ring-1 ring-black/10 backdrop-blur-md dark:bg-neutral-900/70 dark:ring-white/10">
+            <div className="flex flex-col items-center rounded-xl bg-antique/80 p-4 shadow-md ring-1 ring-black/10 backdrop-blur-md">
               <Phone className="mb-2 h-5 w-5 text-[var(--color-accent)]" />
               <p className="text-sm">+1 (555) 123-4567</p>
             </div>
-            <div className="flex flex-col items-center rounded-xl bg-white/80 p-4 shadow-md ring-1 ring-black/10 backdrop-blur-md dark:bg-neutral-900/70 dark:ring-white/10">
+            <div className="flex flex-col items-center rounded-xl bg-antique/80 p-4 shadow-md ring-1 ring-black/10 backdrop-blur-md">
               <Mail className="mb-2 h-5 w-5 text-[var(--color-accent)]" />
               <p className="text-sm">contact@npr-media.com</p>
             </div>
-            <div className="flex flex-col items-center rounded-xl bg-white/80 p-4 shadow-md ring-1 ring-black/10 backdrop-blur-md dark:bg-neutral-900/70 dark:ring-white/10">
+            <div className="flex flex-col items-center rounded-xl bg-antique/80 p-4 shadow-md ring-1 ring-black/10 backdrop-blur-md">
               <Calendar className="mb-2 h-5 w-5 text-[var(--color-accent)]" />
               <a
                 href="https://calendly.com"

--- a/src/app/why-npr/page.tsx
+++ b/src/app/why-npr/page.tsx
@@ -46,17 +46,17 @@ export default function WhyNprPage() {
           className="relative overflow-hidden bg-[var(--color-bg-dark)] py-20 text-[var(--color-text-light)]"
         >
           <div className="pointer-events-none absolute inset-0 -z-10">
-            <div className="absolute -top-10 left-1/2 h-96 w-96 -translate-x-1/2 rounded-full bg-gradient-to-br from-[var(--color-accent)] via-pink-500 to-[var(--color-accent-dark)] opacity-30 blur-3xl" />
+            <div className="absolute -top-10 left-1/2 h-96 w-96 -translate-x-1/2 rounded-full bg-gradient-to-br from-[var(--color-accent)] via-blood to-[var(--color-accent-dark)] opacity-30 blur-3xl" />
           </div>
           <div className="container mx-auto max-w-6xl space-y-12 px-4">
             <div className="space-y-2 text-center">
               <h1 className="text-[clamp(2rem,4vw,3rem)] font-bold tracking-tight">
                 Why Human Strategy Beats AI Guesswork
               </h1>
-              <p className="text-[clamp(0.9rem,1.6vw,1.125rem)] text-gray-300">
+              <p className="text-[clamp(0.9rem,1.6vw,1.125rem)] text-silver">
                 AI can parse data but it can&rsquo;t read minds or context.
               </p>
-              <p className="mx-auto max-w-xl text-sm text-gray-300">
+              <p className="mx-auto max-w-xl text-sm text-silver">
                 Our strategists apply lived experience and own the results from concept to launch.
               </p>
             </div>
@@ -64,7 +64,7 @@ export default function WhyNprPage() {
               <div className="md:grid md:grid-cols-2 md:items-center md:gap-8">
                 <div className="space-y-2 pb-8 text-center md:pb-0 md:text-left">
                   <h2 className="text-3xl font-bold sm:text-4xl">What AI Can’t Do</h2>
-                  <p className="text-sm text-gray-300">
+                  <p className="text-sm text-silver">
                     Where automation simply can&rsquo;t compete
                   </p>
                   <div className="pt-2">
@@ -87,8 +87,8 @@ export default function WhyNprPage() {
                 </motion.div>
               </div>
               <div className="space-y-1 text-center">
-                <h2 className="text-xl font-bold text-gray-100">Here&rsquo;s where we step in</h2>
-                <p className="text-sm text-gray-400">
+                <h2 className="text-xl font-bold text-silver">Here&rsquo;s where we step in</h2>
+                <p className="text-sm text-silver">
                   Real humans refine the data and own the outcome.
                 </p>
                 <ScrollCue
@@ -99,7 +99,7 @@ export default function WhyNprPage() {
               <div id="npr-delivers" className="md:grid md:grid-cols-2 md:items-center md:gap-8">
                 <div className="space-y-2 pb-8 text-center md:pb-0 md:text-left">
                   <h2 className="text-3xl font-bold sm:text-4xl">How NPR Media Delivers</h2>
-                  <p className="text-sm text-gray-300">
+                  <p className="text-sm text-silver">
                     Hands-on strategy that actually moves the needle
                   </p>
                   <div className="pt-2">
@@ -122,7 +122,7 @@ export default function WhyNprPage() {
                 </motion.div>
               </div>
             </div>
-            <p className="mx-auto mt-6 max-w-xl text-center text-sm text-gray-300">
+            <p className="mx-auto mt-6 max-w-xl text-center text-sm text-silver">
               Leaving growth to algorithms only repeats old mistakes. We build every campaign
               hands-on and measure success by your metrics.
             </p>
@@ -149,7 +149,7 @@ export default function WhyNprPage() {
                 </p>
               </motion.div>
             </div>
-            <p className="mt-6 text-center text-sm text-gray-600">
+            <p className="mt-6 text-center text-sm text-silver">
               Skip the bloat and keep momentum with a senior crew measured on outcomes.
             </p>
             <hr className="my-16 h-px border-0 bg-gradient-to-r from-transparent via-white/50 to-transparent" />
@@ -161,7 +161,7 @@ export default function WhyNprPage() {
             >
               <div className="w-1/2 pr-4 text-sm">
                 <p className="mb-2 font-semibold">AI output</p>
-                <div className="rounded bg-indigo-900 p-3 text-white">
+                <div className="rounded bg-umber p-3 text-silver">
                   <TypingText text="10 tips for SEO…" />
                 </div>
               </div>
@@ -188,19 +188,19 @@ export default function WhyNprPage() {
                 Don’t get AI’d. Get outcomes.
               </a>
             </div>
-            <p className="mt-10 text-center text-sm font-semibold text-gray-600">
+            <p className="mt-10 text-center text-sm font-semibold text-silver">
               AI isn&rsquo;t your only risk. Bloated agencies drain budgets and momentum. Keep
               scrolling to see how our lean team drives faster wins.
             </p>
             <ScrollCue href="#vs-firms" className="mx-auto mt-4 text-[var(--color-accent)]" />
           </div>
         </section>
-        <WaveDivider className="text-gray-100" />
+        <WaveDivider className="text-silver" />
 
         {/* SECTION 2: NPR Media vs Other Firms */}
         <section id="vs-firms" className="relative overflow-hidden bg-white py-20 text-black">
           <div className="pointer-events-none absolute inset-0 -z-10">
-            <div className="absolute right-1/2 bottom-0 h-96 w-96 translate-x-1/2 rounded-full bg-gradient-to-br from-[var(--color-accent)] via-pink-400 to-[var(--color-accent-dark)] opacity-30 blur-3xl" />
+            <div className="absolute right-1/2 bottom-0 h-96 w-96 translate-x-1/2 rounded-full bg-gradient-to-br from-[var(--color-accent)] via-blood to-[var(--color-accent-dark)] opacity-30 blur-3xl" />
           </div>
           <div className="container mx-auto max-w-6xl space-y-12 px-4">
             <div className="md:grid md:grid-cols-2 md:items-center md:gap-8">
@@ -208,11 +208,11 @@ export default function WhyNprPage() {
                 <h1 className="text-[clamp(2rem,4vw,3rem)] font-bold tracking-tight">
                   Agency Bloat vs NPR Media
                 </h1>
-                <p className="text-[clamp(0.9rem,1.6vw,1.125rem)] text-gray-600">
+                <p className="text-[clamp(0.9rem,1.6vw,1.125rem)] text-silver">
                   AI tools won&rsquo;t own your numbers&mdash;and neither will bloated agencies.
                   While others bill hours, we deliver outcomes.
                 </p>
-                <p className="mx-auto max-w-xl text-sm text-gray-600 md:mx-0">
+                <p className="mx-auto max-w-xl text-sm text-silver md:mx-0">
                   Large firms pad projects with juniors and endless steps. Our senior strike team
                   ships fast and stands behind every metric.
                 </p>
@@ -225,8 +225,8 @@ export default function WhyNprPage() {
                 <FirmCarousel />
               </motion.div>
             </div>
-            <hr className="my-16 h-px border-0 bg-gradient-to-r from-transparent via-gray-400 to-transparent" />
-            <p className="text-center text-sm font-semibold text-gray-500">
+            <hr className="my-16 h-px border-0 bg-gradient-to-r from-transparent via-silver to-transparent" />
+            <p className="text-center text-sm font-semibold text-silver">
               Here&rsquo;s how we do it differently.
             </p>
             <div className="grid gap-8 text-sm md:grid-cols-2">
@@ -235,10 +235,10 @@ export default function WhyNprPage() {
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
                 transition={{ duration: 0.6 }}
-                className="space-y-2 rounded-xl bg-white p-6 text-gray-800 shadow-md"
+                className="space-y-2 rounded-xl bg-antique p-6 text-charcoal shadow-md"
               >
                 <p className="text-lg font-semibold">What other firms drag you through</p>
-                <p className="text-sm text-gray-500">Extras you don&rsquo;t actually need</p>
+                <p className="text-sm text-silver">Extras you don&rsquo;t actually need</p>
                 <div className="pt-2">
                   <a
                     href="/webdev-landing"
@@ -250,19 +250,19 @@ export default function WhyNprPage() {
                 </div>
                 <ul className="space-y-1 text-sm">
                   <li className="flex items-start gap-2">
-                    <Ban className="h-4 w-4 text-pink-500" />
+                    <Ban className="h-4 w-4 text-blood" />
                     <span>4-week discovery calls</span>
                   </li>
                   <li className="flex items-start gap-2">
-                    <Ban className="h-4 w-4 text-pink-500" />
+                    <Ban className="h-4 w-4 text-blood" />
                     <span>$2k wireframes</span>
                   </li>
                   <li className="flex items-start gap-2">
-                    <Ban className="h-4 w-4 text-pink-500" />
+                    <Ban className="h-4 w-4 text-blood" />
                     <span>Slow handoffs</span>
                   </li>
                   <li className="flex items-start gap-2">
-                    <Ban className="h-4 w-4 text-pink-500" />
+                    <Ban className="h-4 w-4 text-blood" />
                     <span>No CRO testing</span>
                   </li>
                 </ul>
@@ -272,10 +272,10 @@ export default function WhyNprPage() {
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
                 transition={{ duration: 0.6, delay: 0.1 }}
-                className="space-y-2 rounded-xl bg-white p-6 text-gray-800 shadow-md"
+                className="space-y-2 rounded-xl bg-antique p-6 text-charcoal shadow-md"
               >
                 <p className="text-lg font-semibold">How we keep projects moving</p>
-                <p className="text-sm text-gray-500">The NPR no-bloat process</p>
+                <p className="text-sm text-silver">The NPR no-bloat process</p>
                 <div className="pt-2">
                   <a
                     href={Routes.contact}
@@ -324,7 +324,7 @@ export default function WhyNprPage() {
             <ScrollCue href="#footer" className="mx-auto mt-4 text-[var(--color-accent)]" />
           </div>
         </section>
-        <WaveDivider flip className="text-gray-100" />
+        <WaveDivider flip className="text-silver" />
       </main>
       <FinalCTA />
       <FooterSection />

--- a/src/components/CTAButton.tsx
+++ b/src/components/CTAButton.tsx
@@ -8,7 +8,7 @@ interface CTAButtonProps {
   className?: string;
 }
 
-export default function CTAButton({ href, children, event, className = 'inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-sm font-semibold text-black shadow-md transition hover:scale-105' }: CTAButtonProps) {
+export default function CTAButton({ href, children, event, className = 'inline-flex items-center justify-center rounded-full bg-blood px-6 py-3 text-sm font-semibold text-white shadow-md transition hover:scale-105 hover:bg-crimson' }: CTAButtonProps) {
   return (
     <Link href={href} data-event={event} className={className}>
       {children}

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -111,9 +111,9 @@ export default function ContactForm({ onSuccess }: ContactFormProps) {
   };
 
   const inputBase =
-    'w-full rounded-md bg-white/80 dark:bg-neutral-800/80 px-10 py-3 text-sm text-black dark:text-white shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40';
+    'w-full rounded-md bg-antique/80 px-10 py-3 text-sm text-charcoal shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blood/40';
 
-  const iconBase = 'absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-neutral-400';
+  const iconBase = 'absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-silver';
 
   return (
     <motion.form
@@ -122,7 +122,7 @@ export default function ContactForm({ onSuccess }: ContactFormProps) {
       initial={{ opacity: 0, y: 30 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.6 }}
-      className="space-y-6 rounded-2xl bg-white/80 p-6 shadow-xl ring-1 shadow-black/10 ring-transparent backdrop-blur-md hover:ring-blue-500/20 dark:bg-neutral-900/80"
+      className="space-y-6 rounded-2xl bg-antique/80 p-6 shadow-xl ring-1 shadow-black/10 ring-transparent backdrop-blur-md hover:ring-blood/20"
     >
       <motion.div
         className="relative"
@@ -143,7 +143,7 @@ export default function ContactForm({ onSuccess }: ContactFormProps) {
           aria-invalid={!!errors.name}
         />
         {placeholders.name && (
-          <span className="pointer-events-none absolute top-1/2 left-10 -translate-y-1/2 text-sm text-neutral-400">
+          <span className="pointer-events-none absolute top-1/2 left-10 -translate-y-1/2 text-sm text-silver">
             {placeholders.name}
           </span>
         )}
@@ -167,7 +167,7 @@ export default function ContactForm({ onSuccess }: ContactFormProps) {
           aria-invalid={!!errors.email}
         />
         {placeholders.email && (
-          <span className="pointer-events-none absolute top-1/2 left-10 -translate-y-1/2 text-sm text-neutral-400">
+          <span className="pointer-events-none absolute top-1/2 left-10 -translate-y-1/2 text-sm text-silver">
             {placeholders.email}
           </span>
         )}
@@ -196,7 +196,7 @@ export default function ContactForm({ onSuccess }: ContactFormProps) {
           <option value="Not Sure">Not Sure</option>
         </select>
         {!form.budget && (
-          <span className="pointer-events-none absolute top-1/2 left-10 -translate-y-1/2 text-sm text-neutral-400">
+          <span className="pointer-events-none absolute top-1/2 left-10 -translate-y-1/2 text-sm text-silver">
             Budget
           </span>
         )}
@@ -220,7 +220,7 @@ export default function ContactForm({ onSuccess }: ContactFormProps) {
           aria-invalid={!!errors.summary}
         />
         {placeholders.summary && (
-          <span className="pointer-events-none absolute top-1/2 left-10 -translate-y-1/2 text-sm text-neutral-400">
+          <span className="pointer-events-none absolute top-1/2 left-10 -translate-y-1/2 text-sm text-silver">
             {placeholders.summary}
           </span>
         )}
@@ -248,7 +248,7 @@ export default function ContactForm({ onSuccess }: ContactFormProps) {
           <option value="Other">Other</option>
         </select>
         {!form.referral && (
-          <span className="pointer-events-none absolute top-1/2 left-10 -translate-y-1/2 text-sm text-neutral-400">
+          <span className="pointer-events-none absolute top-1/2 left-10 -translate-y-1/2 text-sm text-silver">
             How did you hear about us?
           </span>
         )}
@@ -257,7 +257,7 @@ export default function ContactForm({ onSuccess }: ContactFormProps) {
         type="submit"
         whileHover={{ scale: !loading && !success ? 1.04 : 1 }}
         disabled={loading}
-        className="relative flex w-full items-center justify-center gap-2 rounded-xl bg-black py-3 font-semibold text-white shadow-md ring-2 ring-blue-500/50 transition-transform hover:shadow-lg disabled:opacity-60"
+        className="relative flex w-full items-center justify-center gap-2 rounded-xl bg-blood py-3 font-semibold text-white shadow-md ring-2 ring-blood/50 transition-transform hover:bg-crimson hover:shadow-lg disabled:opacity-60"
       >
         {loading ? (
           <span className="h-5 w-5 animate-spin rounded-full border-2 border-white border-t-transparent" />
@@ -267,7 +267,7 @@ export default function ContactForm({ onSuccess }: ContactFormProps) {
           'Send Message'
         )}
       </motion.button>
-      <div className="space-y-1 text-center text-xs text-neutral-500">
+      <div className="space-y-1 text-center text-xs text-silver">
         <p>No spam. No obligation. Just clarity.</p>
         <p>Trusted by 25+ SaaS, DTC, and consulting brands</p>
       </div>
@@ -275,7 +275,7 @@ export default function ContactForm({ onSuccess }: ContactFormProps) {
         <motion.div
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
-          className="text-center text-sm text-green-600"
+          className="text-center text-sm text-blood"
         >
           We&apos;ll reach out within 1 business day.
           <div className="pt-2">
@@ -283,7 +283,7 @@ export default function ContactForm({ onSuccess }: ContactFormProps) {
               href="https://calendly.com"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-blue-600 underline"
+              className="text-blood underline"
             >
               Book a Call
             </a>

--- a/src/components/StickyCTA.tsx
+++ b/src/components/StickyCTA.tsx
@@ -26,7 +26,7 @@ export default function StickyCTA() {
           exit={{ opacity: 0 }}
           whileHover={{ scale: 1.05 }}
           onClick={handleClick}
-          className="fixed right-4 bottom-4 z-50 flex items-center gap-2 rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-lg md:hidden"
+          className="fixed right-4 bottom-4 z-50 flex items-center gap-2 rounded-full bg-blood px-4 py-2 text-sm font-semibold text-white shadow-lg hover:bg-crimson md:hidden"
         >
           <MessageCircle className="h-4 w-4" /> Message Us
         </motion.button>

--- a/src/components/about/ValuesCarousel.tsx
+++ b/src/components/about/ValuesCarousel.tsx
@@ -108,10 +108,10 @@ export default function ValuesCarousel() {
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ duration: 0.4 }}
                 style={{ opacity }}
-                className="rounded-xl bg-white p-6 text-black shadow"
+                className="rounded-xl bg-antique p-6 text-charcoal shadow"
               >
                 <p className="text-xl leading-snug font-bold">{slide.title}</p>
-                <p className="mt-2 text-lg leading-relaxed text-gray-600">{slide.description}</p>
+                <p className="mt-2 text-lg leading-relaxed text-sepia">{slide.description}</p>
               </motion.div>
             </section>
           );

--- a/src/components/global/Footer.tsx
+++ b/src/components/global/Footer.tsx
@@ -15,7 +15,7 @@ export default function Footer() {
           <CTAButton
             href="/webdev-landing"
             event="cta-footer-get-started"
-            className="inline-block rounded-full bg-white px-6 py-3 text-sm font-semibold text-black shadow-md transition hover:scale-105"
+            className="inline-block rounded-full bg-blood px-6 py-3 text-sm font-semibold text-white shadow-md transition hover:scale-105 hover:bg-crimson"
           >
             Get Started
           </CTAButton>

--- a/src/components/global/Header.tsx
+++ b/src/components/global/Header.tsx
@@ -25,7 +25,7 @@ export default function StickyHeader({ light = false }: HeaderProps) {
     return () => window.removeEventListener('scroll', onScroll);
   }, []);
 
-  const textColor = scrolled || !light ? 'text-[var(--color-text-light)]' : 'text-black';
+  const textColor = scrolled || !light ? 'text-[var(--color-text-light)]' : 'text-charcoal';
 
   return (
     <motion.header
@@ -33,7 +33,7 @@ export default function StickyHeader({ light = false }: HeaderProps) {
       animate={{ y: 0, opacity: 1 }}
       transition={{ duration: 0.6 }}
       className={`fixed top-0 left-0 z-50 w-full transition-all ${
-        scrolled ? 'bg-[#0A0F1C]/90 shadow-md backdrop-blur-sm' : 'backdrop-blur-0 bg-transparent'
+        scrolled ? 'bg-umber/90 shadow-md backdrop-blur-sm' : 'backdrop-blur-0 bg-transparent'
       } ${textColor}`}
     >
       <div
@@ -49,38 +49,38 @@ export default function StickyHeader({ light = false }: HeaderProps) {
         <nav className="hidden items-center gap-[clamp(1.25rem,3vw,2rem)] md:flex">
           <Link
             href="/pricing"
-            className="text-[clamp(0.75rem,1vw,0.875rem)] transition-transform hover:scale-105 hover:text-blue-600"
+            className="text-[clamp(0.75rem,1vw,0.875rem)] transition-transform hover:scale-105 hover:text-blood"
           >
             Pricing
           </Link>
           <Link
             href="/about"
-            className="text-[clamp(0.75rem,1vw,0.875rem)] transition-transform hover:scale-105 hover:text-blue-600"
+            className="text-[clamp(0.75rem,1vw,0.875rem)] transition-transform hover:scale-105 hover:text-blood"
           >
             About
           </Link>
           <Link
             href={Routes.contact}
-            className="text-[clamp(0.75rem,1vw,0.875rem)] transition-transform hover:scale-105 hover:text-blue-600"
+            className="text-[clamp(0.75rem,1vw,0.875rem)] transition-transform hover:scale-105 hover:text-blood"
           >
             Contact
           </Link>
           <Link
             href="/blog"
-            className="text-[clamp(0.75rem,1vw,0.875rem)] transition-transform hover:scale-105 hover:text-blue-600"
+            className="text-[clamp(0.75rem,1vw,0.875rem)] transition-transform hover:scale-105 hover:text-blood"
           >
             Blog
           </Link>
           <Link
             href="/why-npr"
-            className="text-[clamp(0.75rem,1vw,0.875rem)] transition-transform hover:scale-105 hover:text-blue-600"
+            className="text-[clamp(0.75rem,1vw,0.875rem)] transition-transform hover:scale-105 hover:text-blood"
           >
             Why NPR
           </Link>
           <CTAButton
             href="/webdev-landing"
             event="cta-navbar"
-            className="ml-4 inline-flex items-center gap-2 rounded-lg bg-black px-4 py-[0.45rem] text-[clamp(0.65rem,0.9vw,0.75rem)] font-semibold text-white shadow transition-transform hover:scale-105 hover:brightness-110"
+            className="ml-4 inline-flex items-center gap-2 rounded-lg bg-blood px-4 py-[0.45rem] text-[clamp(0.65rem,0.9vw,0.75rem)] font-semibold text-white shadow transition-transform hover:scale-105 hover:bg-crimson"
           >
             Get Started →
           </CTAButton>

--- a/src/components/homepage/ContactSection.tsx
+++ b/src/components/homepage/ContactSection.tsx
@@ -18,23 +18,23 @@ export default function ContactSection() {
       </div>
       <div className="mx-auto max-w-2xl text-center space-y-6">
         <h2 className="text-[clamp(1.75rem,3.5vw,2.5rem)] font-bold">{title}</h2>
-        <p className="text-[clamp(0.9rem,1.6vw,1.125rem)] text-gray-300">{subtitle}</p>
+        <p className="text-[clamp(0.9rem,1.6vw,1.125rem)] text-silver">{subtitle}</p>
         <div className="pt-4">
           <Link
             href={cta.href}
             data-event="cta-final"
-            className="inline-flex items-center justify-center gap-2 rounded-full bg-white px-[clamp(1.25rem,3vw,1.5rem)] py-[clamp(0.6rem,1.2vw,0.75rem)] text-[clamp(0.8rem,1vw,0.9rem)] font-semibold text-black shadow-lg transition hover:scale-105 hover:shadow-xl"
+            className="inline-flex items-center justify-center gap-2 rounded-full bg-blood px-[clamp(1.25rem,3vw,1.5rem)] py-[clamp(0.6rem,1.2vw,0.75rem)] text-[clamp(0.8rem,1vw,0.9rem)] font-semibold text-white shadow-lg transition hover:scale-105 hover:bg-crimson"
           >
             {cta.label}
             <ArrowRight className="h-4 w-4" />
           </Link>
         </div>
-        <p className="text-sm text-gray-400">{trust}</p>
+        <p className="text-sm text-silver">{trust}</p>
         {urgency && <p className="text-xs font-medium text-[var(--color-accent)]">{urgency}</p>}
         <div className="pt-2">
           <Link
             href={exitLink.href}
-            className="text-[clamp(0.75rem,1vw,0.875rem)] text-gray-400 underline-offset-4 hover:underline"
+            className="text-[clamp(0.75rem,1vw,0.875rem)] text-silver underline-offset-4 hover:underline"
           >
             {exitLink.label}
           </Link>

--- a/src/components/homepage/IndustryTemplates.tsx
+++ b/src/components/homepage/IndustryTemplates.tsx
@@ -13,14 +13,14 @@ export default function IndustryTemplatesSection() {
   return (
     <section
       id="templates"
-      className="w-full scroll-mt-[120px] overflow-x-hidden bg-white text-black py-[clamp(5rem,10vw,8rem)]"
+      className="w-full scroll-mt-[120px] overflow-x-hidden bg-antique text-charcoal py-[clamp(5rem,10vw,8rem)]"
     >
       <div className="container mx-auto max-w-4xl px-4 sm:px-6 lg:px-8">
         <div className="mb-12 text-center">
-          <h2 className="text-[#212121] text-[clamp(1.75rem,3.5vw,2.5rem)] font-bold tracking-tight">
+          <h2 className="text-charcoal text-[clamp(1.75rem,3.5vw,2.5rem)] font-bold tracking-tight">
             Authority Platform Demo
           </h2>
-          <p className="text-gray-700 mt-2 text-[clamp(0.9rem,1.6vw,1.125rem)]">
+          <p className="text-sepia mt-2 text-[clamp(0.9rem,1.6vw,1.125rem)]">
             Our premier template for coaches and consultants.
           </p>
         </div>
@@ -44,13 +44,13 @@ export default function IndustryTemplatesSection() {
           <div
             className="flex flex-grow flex-col md:w-1/2 origin-left transform-gpu transition-all duration-500 group-hover:[transform:translateX(1.5rem)_rotateY(-6deg)]"
           >
-            <h4 className="text-[#212121] mb-1 truncate text-[clamp(1rem,1.8vw,1.25rem)] font-semibold">
+            <h4 className="text-charcoal mb-1 truncate text-[clamp(1rem,1.8vw,1.25rem)] font-semibold">
               {authority.title}
             </h4>
-            <p className="text-gray-700 mb-1 text-[clamp(0.8rem,1.2vw,0.9rem)]">
+            <p className="text-sepia mb-1 text-[clamp(0.8rem,1.2vw,0.9rem)]">
               {authority.description}
             </p>
-            <p className="text-gray-500 mb-3 text-[clamp(0.7rem,1vw,0.8rem)] italic">
+            <p className="text-silver mb-3 text-[clamp(0.7rem,1vw,0.8rem)] italic">
               Used by 12+ clients in this industry
             </p>
             <div className="mt-auto text-[clamp(0.8rem,1vw,0.9rem)] font-medium">

--- a/src/components/homepage/QuoteModal.tsx
+++ b/src/components/homepage/QuoteModal.tsx
@@ -19,23 +19,23 @@ export default function QuoteModal({
   return (
     <Dialog.Root onOpenChange={() => setSubmitted(false)}>
       <Dialog.Trigger asChild>
-        <button className="inline-flex items-center justify-center rounded-full bg-white px-6 py-2 text-sm font-semibold text-black shadow hover:bg-gray-200">
+        <button className="inline-flex items-center justify-center rounded-full bg-blood px-6 py-2 text-sm font-semibold text-white shadow hover:bg-crimson">
           {triggerLabel}
         </button>
       </Dialog.Trigger>
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 bg-black/50" />
-        <Dialog.Content className="fixed top-1/2 left-1/2 w-[90vw] max-w-md -translate-x-1/2 -translate-y-1/2 rounded-xl bg-white p-6 text-black shadow-lg">
+        <Dialog.Content className="fixed top-1/2 left-1/2 w-[90vw] max-w-md -translate-x-1/2 -translate-y-1/2 rounded-xl bg-antique p-6 text-charcoal shadow-lg">
           <Dialog.Title className="text-lg font-semibold">Tell us what you need</Dialog.Title>
-          <Dialog.Description className="text-sm text-gray-600">
+          <Dialog.Description className="text-sm text-sepia">
             Your submission is reviewed by our founder — not a sales bot.
           </Dialog.Description>
-          <Dialog.Close className="absolute right-3 top-3 rounded p-1 text-gray-700 hover:bg-gray-100">
+          <Dialog.Close className="absolute right-3 top-3 rounded p-1 text-sepia hover:bg-antique">
             <X className="h-4 w-4" />
           </Dialog.Close>
           {submitted ? (
             <div className="mt-4 flex flex-col items-center space-y-2">
-              <CheckCircle2 className="h-8 w-8 text-green-600" />
+              <CheckCircle2 className="h-8 w-8 text-blood" />
               <p className="text-center text-sm">We&apos;ll respond within 24h with next steps.</p>
             </div>
           ) : (

--- a/src/components/sections/FinalCTA.tsx
+++ b/src/components/sections/FinalCTA.tsx
@@ -2,7 +2,7 @@ import { Routes } from '@/lib/routes';
 
 export default function FinalCTA() {
   return (
-    <section className="bg-neutral-950 px-6 py-20 text-center text-white">
+    <section className="bg-umber px-6 py-20 text-center text-silver">
       <h2 className="mb-4 text-3xl font-bold md:text-4xl">Let’s build something legendary</h2>
       <p className="mx-auto mb-6 max-w-2xl text-lg">
         We craft websites that drive serious results. Book your strategy call today.
@@ -10,11 +10,11 @@ export default function FinalCTA() {
       <a
         href={Routes.contact}
         data-event="cta-final"
-        className="inline-block rounded-lg bg-white px-6 py-3 font-semibold text-black transition hover:bg-neutral-200"
+        className="inline-block rounded-lg bg-blood px-6 py-3 font-semibold text-white transition hover:bg-crimson"
       >
         Book Free Discovery Call
       </a>
-      <p className="mt-4 text-sm text-neutral-400">No pressure. Just clarity and next steps.</p>
+      <p className="mt-4 text-sm text-silver">No pressure. Just clarity and next steps.</p>
     </section>
   );
 }

--- a/src/components/webdevLanding/CTASection.tsx
+++ b/src/components/webdevLanding/CTASection.tsx
@@ -4,7 +4,7 @@ import MiniForm from './MiniForm'
 
 export default function CTASection() {
   return (
-    <section id="cta" className="relative bg-gradient-to-br from-indigo-900 via-purple-800 to-blue-900 py-24 text-white">
+    <section id="cta" className="relative bg-gradient-to-br from-blood via-crimson to-umber py-24 text-silver">
       <div className="mx-auto grid max-w-7xl grid-cols-1 gap-12 px-6 md:px-12 lg:px-20 md:grid-cols-2">
         <motion.div
           initial={{ opacity: 0, y: 20 }}
@@ -15,12 +15,12 @@ export default function CTASection() {
         >
           <h2 className="text-[clamp(2rem,5vw,3rem)] font-bold">Get Your Free Strategy Mockup</h2>
           <p className="text-[clamp(1rem,2vw,1.25rem)]">Share your goals and we’ll map a high-converting website approach—free.</p>
-          <ul className="list-disc pl-5 text-sm marker:text-indigo-300">
+          <ul className="list-disc pl-5 text-sm marker:text-silver">
             <li>Actionable page-level insights</li>
             <li>Senior dev & design expertise</li>
             <li>100% obligation-free</li>
           </ul>
-          <p className="text-sm text-indigo-200">Prefer to schedule a call? <a href="https://calendly.com" target="_blank" className="underline">Book via Calendly</a></p>
+          <p className="text-sm text-silver">Prefer to schedule a call? <a href="https://calendly.com" target="_blank" className="underline">Book via Calendly</a></p>
         </motion.div>
         <MiniForm />
       </div>

--- a/src/components/webdevLanding/Hero.tsx
+++ b/src/components/webdevLanding/Hero.tsx
@@ -14,7 +14,7 @@ const textVariants = {
 
 export default function Hero({ headline, subheadline, cta }: HeroProps) {
   return (
-    <section className="relative flex min-h-screen flex-col items-center justify-center overflow-hidden bg-gradient-to-br from-indigo-900 via-purple-800 to-blue-900 text-center text-white">
+    <section className="relative flex min-h-screen flex-col items-center justify-center overflow-hidden bg-gradient-to-br from-umber via-olive to-charcoal text-center text-silver">
       <motion.div
         initial="hidden"
         whileInView="visible"
@@ -38,7 +38,7 @@ export default function Hero({ headline, subheadline, cta }: HeroProps) {
           variants={textVariants}
           href="#cta"
           data-event="webdev-scroll-trigger"
-          className="mt-8 inline-block rounded-full bg-white px-6 py-3 font-semibold text-black shadow-lg ring-1 ring-white/10 transition hover:scale-105"
+          className="mt-8 inline-block rounded-full bg-blood px-6 py-3 font-semibold text-white shadow-lg ring-1 ring-white/10 transition hover:bg-crimson hover:scale-105"
         >
           {cta}
         </motion.a>

--- a/src/components/webdevLanding/MiniForm.tsx
+++ b/src/components/webdevLanding/MiniForm.tsx
@@ -21,9 +21,9 @@ export default function MiniForm() {
     setTimeout(() => setSuccess(false), 2500)
   }
 
-  const baseInput = 'peer w-full rounded-md bg-white/80 px-10 py-3 text-sm text-black shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/40 placeholder-transparent'
-  const iconBase = 'absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-neutral-400 pointer-events-none'
-  const labelBase = 'pointer-events-none absolute left-10 top-1/2 -translate-y-1/2 text-sm text-neutral-500 transition-all peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2 peer-focus:top-2 peer-focus:-translate-y-0 peer-focus:text-xs'
+  const baseInput = 'peer w-full rounded-md bg-antique/80 px-10 py-3 text-sm text-charcoal shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blood/40 placeholder-transparent'
+  const iconBase = 'absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-silver pointer-events-none'
+  const labelBase = 'pointer-events-none absolute left-10 top-1/2 -translate-y-1/2 text-sm text-silver transition-all peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2 peer-focus:top-2 peer-focus:-translate-y-0 peer-focus:text-xs'
 
   return (
     <motion.form
@@ -32,7 +32,7 @@ export default function MiniForm() {
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true }}
       transition={{ duration: 0.6, delay: 0.2 }}
-      className="space-y-4 rounded-2xl bg-white/20 p-6 shadow-xl ring-1 ring-white/10 backdrop-blur"
+      className="space-y-4 rounded-2xl bg-antique/20 p-6 shadow-xl ring-1 ring-white/10 backdrop-blur"
     >
       <div className="relative">
         <User className={iconBase} />
@@ -65,11 +65,11 @@ export default function MiniForm() {
         data-event="webdev-cta-submit"
         whileHover={{ scale: !loading && !success ? 1.05 : 1 }}
         disabled={loading || success}
-        className="relative flex w-full items-center justify-center gap-2 rounded-xl bg-indigo-600 py-3 font-semibold text-white shadow-md transition"
+        className="relative flex w-full items-center justify-center gap-2 rounded-xl bg-blood py-3 font-semibold text-white shadow-md transition hover:bg-crimson"
       >
         {loading ? <span className="h-5 w-5 animate-spin rounded-full border-2 border-white border-t-transparent" /> : success ? <Check className="h-5 w-5" /> : 'Start My Mockup'}
       </motion.button>
-      {success && <p className="pt-2 text-center text-sm text-indigo-200">We’ll be in touch shortly.</p>}
+      {success && <p className="pt-2 text-center text-sm text-silver">We’ll be in touch shortly.</p>}
     </motion.form>
   )
 }

--- a/src/components/webdevLanding/OfferStack.tsx
+++ b/src/components/webdevLanding/OfferStack.tsx
@@ -12,7 +12,7 @@ const items = [
 
 export default function OfferStack() {
   return (
-    <section className="bg-neutral-100 py-24">
+    <section className="bg-antique py-24">
       <div className="mx-auto max-w-7xl px-6 md:px-12 lg:px-20">
         <motion.h2
           initial={{ opacity: 0, y: 20 }}
@@ -31,11 +31,11 @@ export default function OfferStack() {
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               transition={{ duration: 0.5, delay: i * 0.1 }}
-              className="rounded-2xl bg-white/70 p-6 text-center shadow-xl ring-1 ring-black/10 backdrop-blur-md hover:shadow-2xl"
+              className="rounded-2xl bg-antique/70 p-6 text-center shadow-xl ring-1 ring-black/10 backdrop-blur-md hover:shadow-2xl"
             >
-              <item.icon className="mx-auto mb-3 h-6 w-6 text-indigo-600" />
+              <item.icon className="mx-auto mb-3 h-6 w-6 text-blood" />
               <h3 className="mb-1 font-semibold text-[clamp(1rem,1.6vw,1.25rem)]">{item.label}</h3>
-              <p className="text-sm text-neutral-700">{item.text}</p>
+              <p className="text-sm text-charcoal">{item.text}</p>
             </motion.div>
           ))}
         </div>

--- a/src/components/webdevLanding/PainPoints.tsx
+++ b/src/components/webdevLanding/PainPoints.tsx
@@ -34,13 +34,13 @@ export default function PainPoints() {
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.5, delay: i * 0.1 }}
-            className="rounded-2xl bg-white/60 p-6 text-center shadow-xl ring-1 ring-black/10 backdrop-blur-md hover:shadow-2xl"
+            className="rounded-2xl bg-antique/60 p-6 text-center shadow-xl ring-1 ring-black/10 backdrop-blur-md hover:shadow-2xl"
           >
-            <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-indigo-500/20 text-indigo-400">
+            <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-blood/20 text-blood">
               {p.icon}
             </div>
             <h3 className="mb-2 font-semibold text-[clamp(1.1rem,1.8vw,1.25rem)]">{p.title}</h3>
-            <p className="text-sm text-neutral-700">{p.text}</p>
+            <p className="text-sm text-charcoal">{p.text}</p>
           </motion.div>
         ))}
       </div>

--- a/src/components/webdevLanding/PricingPreview.tsx
+++ b/src/components/webdevLanding/PricingPreview.tsx
@@ -30,7 +30,7 @@ export default function PricingPreview() {
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           transition={{ duration: 0.6, delay: 0.2 }}
-          className="mt-8 inline-block rounded-full bg-indigo-600 px-6 py-3 font-semibold text-white shadow-lg transition hover:scale-105"
+          className="mt-8 inline-block rounded-full bg-blood px-6 py-3 font-semibold text-white shadow-lg transition hover:bg-crimson hover:scale-105"
         >
           Let’s Build Your Quote
         </motion.a>
@@ -39,7 +39,7 @@ export default function PricingPreview() {
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           transition={{ duration: 0.6, delay: 0.3 }}
-          className="mt-4 text-sm text-neutral-600"
+          className="mt-4 text-sm text-charcoal"
         >
           We respond to every serious request within 1 business day.
         </motion.p>

--- a/src/components/webdevLanding/Proof.tsx
+++ b/src/components/webdevLanding/Proof.tsx
@@ -40,11 +40,11 @@ export default function Proof() {
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               transition={{ duration: 0.5, delay: i * 0.1 }}
-              className="rounded-2xl bg-white/70 p-6 shadow-xl ring-1 ring-black/10 backdrop-blur-md hover:shadow-2xl"
+              className="rounded-2xl bg-antique/70 p-6 shadow-xl ring-1 ring-black/10 backdrop-blur-md hover:shadow-2xl"
             >
               <p className="text-sm italic">&ldquo;{t.quote}&rdquo;</p>
               <p className="mt-4 font-semibold">{t.name}</p>
-              <p className="text-xs text-neutral-500">{t.title}</p>
+              <p className="text-xs text-silver">{t.title}</p>
             </motion.div>
           ))}
         </div>

--- a/src/components/whyNpr/AiCarousel.tsx
+++ b/src/components/whyNpr/AiCarousel.tsx
@@ -66,7 +66,7 @@ export default function AiCarousel() {
                   animate={{ opacity: 1, y: 0 }}
                   exit={{ opacity: 0, y: -30 }}
                   transition={{ duration: 0.5 }}
-                  className="mx-auto w-[clamp(16rem,40vw,22rem)] space-y-4 rounded-xl border border-white/10 bg-[var(--color-card)] p-6 text-center text-gray-100 shadow-2xl"
+                  className="mx-auto w-[clamp(16rem,40vw,22rem)] space-y-4 rounded-xl border border-white/10 bg-[var(--color-card)] p-6 text-center text-silver shadow-2xl"
                 >
                   <h2 className="text-2xl font-bold">{title}</h2>
                   <ul className="list-disc space-y-1 pl-5 text-left text-sm">

--- a/src/components/whyNpr/FirmCarousel.tsx
+++ b/src/components/whyNpr/FirmCarousel.tsx
@@ -85,21 +85,21 @@ export default function FirmCarousel() {
                   animate={{ opacity: 1, y: 0 }}
                   exit={{ opacity: 0, y: -30 }}
                   transition={{ duration: 0.5 }}
-                  className="mx-auto w-[clamp(18rem,60vw,28rem)] rounded-xl border border-black/10 bg-gradient-to-br from-gray-50 via-white to-gray-200 p-6 text-black shadow-2xl"
+                  className="mx-auto w-[clamp(18rem,60vw,28rem)] rounded-xl border border-black/10 bg-gradient-to-br from-antique via-sepia to-olive p-6 text-charcoal shadow-2xl"
                 >
                   <div className="grid grid-cols-[1fr_auto_1fr_auto_1fr] items-center gap-4">
                     <div>
-                      <p className="text-xs font-semibold text-gray-500">Other Firms</p>
+                      <p className="text-xs font-semibold text-silver">Other Firms</p>
                       <p className="text-sm">{row.other}</p>
                     </div>
-                    <ArrowRight className="mx-auto text-gray-400" />
+                    <ArrowRight className="mx-auto text-silver" />
                     <div>
-                      <p className="text-xs font-semibold text-gray-500">NPR Media</p>
+                      <p className="text-xs font-semibold text-silver">NPR Media</p>
                       <p className="text-sm">{row.npr}</p>
                     </div>
-                    <ArrowRight className="mx-auto text-gray-400" />
+                    <ArrowRight className="mx-auto text-silver" />
                     <div>
-                      <p className="text-xs font-semibold text-gray-500">Your Gain</p>
+                      <p className="text-xs font-semibold text-silver">Your Gain</p>
                       <p className="text-sm">{row.gain}</p>
                     </div>
                   </div>

--- a/src/components/whyNpr/NprCarousel.tsx
+++ b/src/components/whyNpr/NprCarousel.tsx
@@ -65,7 +65,7 @@ export default function NprCarousel() {
                   animate={{ opacity: 1, x: 0 }}
                   exit={{ opacity: 0, x: -30 }}
                   transition={{ duration: 0.5 }}
-                  className="mx-auto w-[clamp(16rem,40vw,22rem)] space-y-4 rounded-xl border border-white/10 bg-gradient-to-br from-[var(--color-accent)] via-pink-600 to-[var(--color-accent-dark)] p-6 text-center text-gray-100 shadow-2xl"
+                  className="mx-auto w-[clamp(16rem,40vw,22rem)] space-y-4 rounded-xl border border-white/10 bg-gradient-to-br from-[var(--color-accent)] via-blood to-[var(--color-accent-dark)] p-6 text-center text-silver shadow-2xl"
                 >
                   <h2 className="text-2xl font-bold">{title}</h2>
                   <ul className="list-disc space-y-1 pl-5 text-left text-sm">

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -13,18 +13,18 @@
   --font-grotesk: 'Space Grotesk', sans-serif;
 
   /* Brand Colors */
-  --color-bg-dark: #111827;
-  --color-card: #1e293b;
-  --color-text-light: #f1f5f9;
-  --color-accent: #e11d48;
-  --color-accent-rgb: 225, 29, 72;
-  --color-accent-dark: #be123c;
+  --color-bg-dark: #3b3224;
+  --color-card: #786c4f;
+  --color-text-light: #d2d2d2;
+  --color-accent: #b30000;
+  --color-accent-rgb: 179, 0, 0;
+  --color-accent-dark: #7a0000;
 
   /* Neutral Palette */
-  --color-gray-300: #cbd5e1;
-  --color-gray-400: #94a3b8;
-  --color-gray-600: #475569;
-  --color-gray-700: #334155;
+  --color-gray-300: #d7c7a5;
+  --color-gray-400: #b7a077;
+  --color-gray-600: #786c4f;
+  --color-gray-700: #3b3224;
 }
 
 html {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,6 +4,20 @@ const defaultTheme = require('tailwindcss/defaultTheme');
 module.exports = {
   content: ['./src/**/*.{js,ts,jsx,tsx,html}'],
   theme: {
+    colors: {
+      antique: '#d7c7a5',
+      sepia: '#b7a077',
+      olive: '#786c4f',
+      umber: '#3b3224',
+      silver: '#d2d2d2',
+      charcoal: '#2f2f2f',
+      blood: '#b30000',
+      crimson: '#7a0000',
+      white: '#ffffff',
+      black: '#000000',
+      transparent: 'transparent',
+      current: 'currentColor',
+    },
     extend: {
       fontFamily: {
         didot: ['"GFS Didot"', 'serif'],


### PR DESCRIPTION
## Summary
- overhaul Tailwind config with antique/sepia/olive/umber palette
- redefine CSS variables with the new hues
- update components and pages to use new color classes
- swap default CTA styles to blood red
- remove legacy Tailwind color names

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68640e14269483289297147dbccec0eb