### PR TITLE
Refactor color usage

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -12,33 +12,33 @@ export default function AboutPage() {
     <section>
       <StickyHeader />
       <main
-        className="relative w-full overflow-x-hidden bg-[var(--color-bg-dark)] text-[var(--color-text-light)]"
+        className="relative w-full overflow-x-hidden bg-background text-foreground"
         style={{ paddingTop: 'calc(var(--header-height) + 1rem)' }}
       >
         {/* Hero */}
         <section
-          className="bg-[var(--color-bg-dark)] text-[var(--color-text-light)] py-[clamp(5rem,10vw,8rem)] px-4 text-center"
+          className="bg-background text-foreground py-[clamp(5rem,10vw,8rem)] px-4 text-center"
         >
           <h1 className="text-[clamp(2rem,4vw,3rem)] font-bold">About NPR Media</h1>
-          <p className="mx-auto mt-4 max-w-2xl text-[clamp(0.9rem,1.6vw,1.125rem)] text-silver">
+          <p className="mx-auto mt-4 max-w-2xl text-[clamp(0.9rem,1.6vw,1.125rem)] text-foreground">
             We craft high-performing websites and systems that help founders and startups scale faster.
           </p>
         </section>
 
         {/* Values */}
-        <section className="relative overflow-hidden py-20 bg-antique text-charcoal">
+        <section className="relative overflow-hidden py-20 bg-surface text-foreground">
           <div className="pointer-events-none absolute inset-0 -z-10">
-            <div className="absolute -top-10 left-1/2 h-96 w-96 -translate-x-1/2 rounded-full bg-gradient-to-br from-[var(--color-accent)] via-pink-300 to-[var(--color-accent-dark)] opacity-20 blur-3xl" />
+            <div className="absolute -top-10 left-1/2 h-96 w-96 -translate-x-1/2 rounded-full bg-gradient-to-br from-accent via-pink-300 to-accent opacity-20 blur-3xl" />
           </div>
           <div className="container mx-auto max-w-6xl px-4 md:grid md:grid-cols-2 md:items-center md:gap-8">
             <div className="pb-8 text-center md:pb-0 md:text-left space-y-2">
               <h2 className="text-3xl sm:text-4xl font-bold">Values, Culture & Beliefs</h2>
-              <p className="text-sm text-charcoal">Principles that guide every build</p>
+              <p className="text-sm text-foreground">Principles that guide every build</p>
               <div className="pt-2">
                 <CTAButton
                   href="/webdev-landing"
                   event="cta-about-values"
-                  className="inline-block rounded-full bg-gradient-to-r from-[var(--color-accent)] to-[var(--color-accent-dark)] px-4 py-2 text-xs font-normal text-silver shadow transition hover:scale-105"
+                  className="inline-block rounded-full bg-gradient-to-r from-accent to-accent px-4 py-2 text-xs font-normal text-foreground shadow transition hover:scale-105"
                 >
                   Work with us
                 </CTAButton>
@@ -56,25 +56,25 @@ export default function AboutPage() {
         </section>
 
         {/* Approach */}
-        <section className="bg-[var(--color-bg-dark)] text-[var(--color-text-light)] py-[clamp(4rem,8vw,6rem)] px-4">
+        <section className="bg-background text-foreground py-[clamp(4rem,8vw,6rem)] px-4">
           <div className="mx-auto grid max-w-4xl gap-8 md:grid-cols-3 text-center">
             <div className="space-y-2">
               <h3 className="text-xl font-bold">Strategy First</h3>
-              <p className="text-sm text-silver">Every build starts with clear goals so your site drives real revenue.</p>
+              <p className="text-sm text-foreground">Every build starts with clear goals so your site drives real revenue.</p>
             </div>
             <div className="space-y-2">
               <h3 className="text-xl font-bold">Senior Expertise</h3>
-              <p className="text-sm text-silver">A compact team of vets ships faster than bloated agencies.</p>
+              <p className="text-sm text-foreground">A compact team of vets ships faster than bloated agencies.</p>
             </div>
             <div className="space-y-2">
               <h3 className="text-xl font-bold">Proven Results</h3>
-              <p className="text-sm text-silver">From SaaS dashboards to marketing sites, our work converts.</p>
+              <p className="text-sm text-foreground">From SaaS dashboards to marketing sites, our work converts.</p>
             </div>
           </div>
         </section>
 
         {/* Team */}
-        <section className="relative bg-antique text-charcoal py-[clamp(4rem,8vw,6rem)] px-4">
+        <section className="relative bg-surface text-foreground py-[clamp(4rem,8vw,6rem)] px-4">
           <div className="pointer-events-none absolute inset-0 z-0 grid grid-cols-3 gap-0">
             <div
               className="h-full w-full bg-cover bg-center"
@@ -98,7 +98,7 @@ export default function AboutPage() {
               }}
             />
           </div>
-          <div className="pointer-events-none absolute inset-0 z-10 bg-[#f8f3e3]/60" />
+          <div className="pointer-events-none absolute inset-0 z-10 bg-background/60" />
           <div className="relative z-20 mx-auto max-w-md text-center space-y-8">
             <h2 className="text-2xl font-bold">Meet the Team</h2>
             <div className="flex justify-center">
@@ -108,24 +108,24 @@ export default function AboutPage() {
                   alt="Taylor portrait"
                   width={300}
                   height={400}
-                  className="mx-auto h-64 w-48 rounded-md object-cover shadow-2xl shadow-black/40"
+                  className="mx-auto h-64 w-48 rounded-md object-cover shadow-2xl shadow-muted/40"
                 />
                 <p className="font-normal">Taylor</p>
-                <p className="text-sm text-charcoal">Founder & CEO</p>
+                <p className="text-sm text-foreground">Founder & CEO</p>
               </div>
             </div>
           </div>
         </section>
 
         {/* CTA */}
-        <section className="bg-[var(--color-bg-dark)] text-[var(--color-text-light)] py-[clamp(4rem,8vw,6rem)] px-4 text-center">
+        <section className="bg-background text-foreground py-[clamp(4rem,8vw,6rem)] px-4 text-center">
           <h2 className="text-2xl font-bold">Ready to accelerate?</h2>
-          <p className="mx-auto mt-2 max-w-xl text-sm text-silver">Let&rsquo;s craft a website that scales with you. See how our process works.</p>
+          <p className="mx-auto mt-2 max-w-xl text-sm text-foreground">Let&rsquo;s craft a website that scales with you. See how our process works.</p>
           <div className="pt-6">
             <CTAButton
               href="/webdev-landing"
               event="cta-about-final"
-              className="inline-block rounded-full bg-[var(--color-accent)] px-6 py-3 text-sm font-normal text-silver shadow-md transition hover:scale-105 hover:bg-[var(--color-accent-dark)]"
+              className="inline-block rounded-full bg-accent px-6 py-3 text-sm font-normal text-foreground shadow-md transition hover:scale-105 hover:bg-accent"
             >
               See Our Process
             </CTAButton>

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -44,7 +44,7 @@ export default function ContactPage() {
         <div className="relative mx-auto w-full max-w-3xl space-y-8">
           <div className="pointer-events-none absolute inset-0 -z-10">
             <motion.div
-              className="h-72 w-72 rounded-full bg-blood/30 blur-3xl"
+              className="h-72 w-72 rounded-full bg-primary/30 blur-3xl"
               animate={{ opacity: [0.5, 1, 0.5], scale: [0.9, 1.1, 0.9] }}
               transition={{ duration: 8, repeat: Infinity }}
             />
@@ -65,16 +65,16 @@ export default function ContactPage() {
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.6, delay: 0.2 }}
           >
-            <div className="flex flex-col items-center rounded-xl bg-antique/80 p-4 shadow-md ring-1 ring-umber/20 backdrop-blur-md">
-              <Phone className="mb-2 h-5 w-5 text-[var(--color-accent)]" />
+            <div className="flex flex-col items-center rounded-xl bg-surface/80 p-4 shadow-md ring-1 ring-umber/20 backdrop-blur-md">
+              <Phone className="mb-2 h-5 w-5 text-accent" />
               <p className="text-sm">+1 (555) 123-4567</p>
             </div>
-            <div className="flex flex-col items-center rounded-xl bg-antique/80 p-4 shadow-md ring-1 ring-umber/20 backdrop-blur-md">
-              <Mail className="mb-2 h-5 w-5 text-[var(--color-accent)]" />
+            <div className="flex flex-col items-center rounded-xl bg-surface/80 p-4 shadow-md ring-1 ring-umber/20 backdrop-blur-md">
+              <Mail className="mb-2 h-5 w-5 text-accent" />
               <p className="text-sm">contact@npr-media.com</p>
             </div>
-            <div className="flex flex-col items-center rounded-xl bg-antique/80 p-4 shadow-md ring-1 ring-umber/20 backdrop-blur-md">
-              <Calendar className="mb-2 h-5 w-5 text-[var(--color-accent)]" />
+            <div className="flex flex-col items-center rounded-xl bg-surface/80 p-4 shadow-md ring-1 ring-umber/20 backdrop-blur-md">
+              <Calendar className="mb-2 h-5 w-5 text-accent" />
               <a
                 href="https://calendly.com"
                 target="_blank"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,7 +16,7 @@ export default function Page() {
   return (
     <section>
       <StickyHeader light />
-      <main key={pathname} className="relative w-full overflow-x-hidden bg-antique text-charcoal">
+      <main key={pathname} className="relative w-full overflow-x-hidden bg-surface text-foreground">
         <Suspense>
           <HeroSection {...hero} />
         </Suspense>

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -7,7 +7,7 @@ export default function PricingPage() {
   return (
     <section>
       <StickyHeader light />
-      <main className="relative w-full overflow-x-hidden bg-antique text-charcoal">
+      <main className="relative w-full overflow-x-hidden bg-surface text-foreground">
         <PricingSection />
       </main>
       <FinalCTA />

--- a/src/app/why-npr/page.tsx
+++ b/src/app/why-npr/page.tsx
@@ -37,26 +37,26 @@ export default function WhyNprPage() {
     <section>
       <StickyHeader />
       <main
-        className="relative w-full space-y-24 overflow-x-hidden bg-[var(--color-bg-dark)] text-[var(--color-text-light)]"
+        className="relative w-full space-y-24 overflow-x-hidden bg-background text-foreground"
         style={{ paddingTop: 'calc(var(--header-height) + 1rem)' }}
       >
         {/* SECTION 1: NPR Media vs AI */}
         <section
           id="vs-ai"
-          className="relative overflow-hidden bg-[var(--color-bg-dark)] py-20 text-[var(--color-text-light)]"
+          className="relative overflow-hidden bg-background py-20 text-foreground"
         >
           <div className="pointer-events-none absolute inset-0 -z-10">
-            <div className="absolute -top-10 left-1/2 h-96 w-96 -translate-x-1/2 rounded-full bg-gradient-to-br from-[var(--color-accent)] via-pink-500 to-[var(--color-accent-dark)] opacity-30 blur-3xl" />
+            <div className="absolute -top-10 left-1/2 h-96 w-96 -translate-x-1/2 rounded-full bg-gradient-to-br from-accent via-pink-500 to-accent opacity-30 blur-3xl" />
           </div>
           <div className="container mx-auto max-w-6xl space-y-12 px-4">
             <div className="space-y-2 text-center">
               <h1 className="text-[clamp(2rem,4vw,3rem)] font-bold tracking-tight">
                 Why Human Strategy Beats AI Guesswork
               </h1>
-              <p className="text-[clamp(0.9rem,1.6vw,1.125rem)] text-silver">
+              <p className="text-[clamp(0.9rem,1.6vw,1.125rem)] text-foreground">
                 AI can parse data but it can&rsquo;t read minds or context.
               </p>
-              <p className="mx-auto max-w-xl text-sm text-silver">
+              <p className="mx-auto max-w-xl text-sm text-foreground">
                 Our strategists apply lived experience and own the results from concept to launch.
               </p>
             </div>
@@ -64,14 +64,14 @@ export default function WhyNprPage() {
               <div className="md:grid md:grid-cols-2 md:items-center md:gap-8">
                 <div className="space-y-2 pb-8 text-center md:pb-0 md:text-left">
                   <h2 className="text-3xl font-bold sm:text-4xl">What AI Can’t Do</h2>
-                  <p className="text-sm text-silver">
+                  <p className="text-sm text-foreground">
                     Where automation simply can&rsquo;t compete
                   </p>
                   <div className="pt-2">
                     <a
                       href="/webdev-landing"
                       data-event="cta-social-proof"
-                      className="inline-block rounded-full bg-gradient-to-r from-[var(--color-accent)] to-[var(--color-accent-dark)] px-4 py-2 text-xs font-semibold text-silver shadow transition hover:scale-105"
+                      className="inline-block rounded-full bg-gradient-to-r from-accent to-accent px-4 py-2 text-xs font-semibold text-foreground shadow transition hover:scale-105"
                     >
                       See the difference
                     </a>
@@ -87,26 +87,26 @@ export default function WhyNprPage() {
                 </motion.div>
               </div>
               <div className="space-y-1 text-center">
-                <h2 className="text-xl font-bold text-silver">Here&rsquo;s where we step in</h2>
-                <p className="text-sm text-silver">
+                <h2 className="text-xl font-bold text-foreground">Here&rsquo;s where we step in</h2>
+                <p className="text-sm text-foreground">
                   Real humans refine the data and own the outcome.
                 </p>
                 <ScrollCue
                   href="#npr-delivers"
-                  className="mx-auto mt-2 text-[var(--color-accent)]"
+                  className="mx-auto mt-2 text-accent"
                 />
               </div>
               <div id="npr-delivers" className="md:grid md:grid-cols-2 md:items-center md:gap-8">
                 <div className="space-y-2 pb-8 text-center md:pb-0 md:text-left">
                   <h2 className="text-3xl font-bold sm:text-4xl">How NPR Media Delivers</h2>
-                  <p className="text-sm text-silver">
+                  <p className="text-sm text-foreground">
                     Hands-on strategy that actually moves the needle
                   </p>
                   <div className="pt-2">
                     <a
                       href="/webdev-landing"
                       data-event="cta-social-proof"
-                      className="inline-block rounded-full bg-gradient-to-r from-[var(--color-accent)] to-[var(--color-accent-dark)] px-4 py-2 text-xs font-semibold text-silver shadow transition hover:scale-105"
+                      className="inline-block rounded-full bg-gradient-to-r from-accent to-accent px-4 py-2 text-xs font-semibold text-foreground shadow transition hover:scale-105"
                     >
                       Explore our approach
                     </a>
@@ -122,7 +122,7 @@ export default function WhyNprPage() {
                 </motion.div>
               </div>
             </div>
-            <p className="mx-auto mt-6 max-w-xl text-center text-sm text-silver">
+            <p className="mx-auto mt-6 max-w-xl text-center text-sm text-foreground">
               Leaving growth to algorithms only repeats old mistakes. We build every campaign
               hands-on and measure success by your metrics.
             </p>
@@ -133,7 +133,7 @@ export default function WhyNprPage() {
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
                 transition={{ duration: 0.6 }}
-                className="rounded-xl bg-silver/10 p-6 text-silver shadow-lg"
+                className="rounded-xl bg-silver/10 p-6 text-foreground shadow-lg"
               >
                 <p className="font-semibold">“Client X wouldn’t exist if we used AI.”</p>
               </motion.div>
@@ -142,14 +142,14 @@ export default function WhyNprPage() {
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
                 transition={{ duration: 0.6, delay: 0.1 }}
-                className="rounded-xl bg-silver/10 p-6 text-silver shadow-lg"
+                className="rounded-xl bg-silver/10 p-6 text-foreground shadow-lg"
               >
                 <p className="font-semibold">
                   “Our last launch doubled signups after a human-led overhaul.”
                 </p>
               </motion.div>
             </div>
-            <p className="mt-6 text-center text-sm text-charcoal">
+            <p className="mt-6 text-center text-sm text-foreground">
               Skip the bloat and keep momentum with a senior crew measured on outcomes.
             </p>
             <hr className="my-16 h-px border-0 bg-gradient-to-r from-transparent via-white/50 to-transparent" />
@@ -157,11 +157,11 @@ export default function WhyNprPage() {
               initial={{ opacity: 0 }}
               whileInView={{ opacity: 1 }}
               viewport={{ once: true }}
-              className="relative mt-12 flex items-start justify-center rounded-xl bg-silver/5 p-6 text-silver shadow-lg md:p-8"
+              className="relative mt-12 flex items-start justify-center rounded-xl bg-silver/5 p-6 text-foreground shadow-lg md:p-8"
             >
               <div className="w-1/2 pr-4 text-sm">
                 <p className="mb-2 font-semibold">AI output</p>
-                <div className="rounded bg-umber p-3 text-silver">
+                <div className="rounded bg-muted p-3 text-foreground">
                   <TypingText text="10 tips for SEO…" />
                 </div>
               </div>
@@ -173,7 +173,7 @@ export default function WhyNprPage() {
                   whileInView={{ opacity: 1, y: 0 }}
                   viewport={{ once: true }}
                   transition={{ duration: 0.6 }}
-                  className="rounded border border-silver/30 bg-silver/10 p-3 text-silver shadow-inner"
+                  className="rounded border border-silver/30 bg-silver/10 p-3 text-foreground shadow-inner"
                 >
                   Bold hook → stat → CTA
                 </motion.div>
@@ -183,24 +183,24 @@ export default function WhyNprPage() {
               <a
                 href="/webdev-landing"
                 data-event="cta-social-proof"
-                className="inline-block rounded-full bg-gradient-to-r from-[var(--color-accent)] to-[var(--color-accent-dark)] px-6 py-3 text-sm font-semibold text-silver shadow-md ring-1 ring-silver/10 transition hover:scale-105"
+                className="inline-block rounded-full bg-gradient-to-r from-accent to-accent px-6 py-3 text-sm font-semibold text-foreground shadow-md ring-1 ring-silver/10 transition hover:scale-105"
               >
                 Don’t get AI’d. Get outcomes.
               </a>
             </div>
-            <p className="mt-10 text-center text-sm font-semibold text-charcoal">
+            <p className="mt-10 text-center text-sm font-semibold text-foreground">
               AI isn&rsquo;t your only risk. Bloated agencies drain budgets and momentum. Keep
               scrolling to see how our lean team drives faster wins.
             </p>
-            <ScrollCue href="#vs-firms" className="mx-auto mt-4 text-[var(--color-accent)]" />
+            <ScrollCue href="#vs-firms" className="mx-auto mt-4 text-accent" />
           </div>
         </section>
-        <WaveDivider className="text-silver" />
+        <WaveDivider className="text-foreground" />
 
         {/* SECTION 2: NPR Media vs Other Firms */}
-        <section id="vs-firms" className="relative overflow-hidden bg-antique py-20 text-charcoal">
+        <section id="vs-firms" className="relative overflow-hidden bg-surface py-20 text-foreground">
           <div className="pointer-events-none absolute inset-0 -z-10">
-            <div className="absolute right-1/2 bottom-0 h-96 w-96 translate-x-1/2 rounded-full bg-gradient-to-br from-[var(--color-accent)] via-pink-400 to-[var(--color-accent-dark)] opacity-30 blur-3xl" />
+            <div className="absolute right-1/2 bottom-0 h-96 w-96 translate-x-1/2 rounded-full bg-gradient-to-br from-accent via-pink-400 to-accent opacity-30 blur-3xl" />
           </div>
           <div className="container mx-auto max-w-6xl space-y-12 px-4">
             <div className="md:grid md:grid-cols-2 md:items-center md:gap-8">
@@ -208,11 +208,11 @@ export default function WhyNprPage() {
                 <h1 className="text-[clamp(2rem,4vw,3rem)] font-bold tracking-tight">
                   Agency Bloat vs NPR Media
                 </h1>
-                <p className="text-[clamp(0.9rem,1.6vw,1.125rem)] text-charcoal">
+                <p className="text-[clamp(0.9rem,1.6vw,1.125rem)] text-foreground">
                   AI tools won&rsquo;t own your numbers&mdash;and neither will bloated agencies.
                   While others bill hours, we deliver outcomes.
                 </p>
-                <p className="mx-auto max-w-xl text-sm text-charcoal md:mx-0">
+                <p className="mx-auto max-w-xl text-sm text-foreground md:mx-0">
                   Large firms pad projects with juniors and endless steps. Our senior strike team
                   ships fast and stands behind every metric.
                 </p>
@@ -226,7 +226,7 @@ export default function WhyNprPage() {
               </motion.div>
             </div>
             <hr className="my-16 h-px border-0 bg-gradient-to-r from-transparent via-silver to-transparent" />
-            <p className="text-center text-sm font-semibold text-charcoal">
+            <p className="text-center text-sm font-semibold text-foreground">
               Here&rsquo;s how we do it differently.
             </p>
             <div className="grid gap-8 text-sm md:grid-cols-2">
@@ -235,15 +235,15 @@ export default function WhyNprPage() {
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
                 transition={{ duration: 0.6 }}
-                className="space-y-2 rounded-xl bg-antique p-6 text-charcoal shadow-md"
+                className="space-y-2 rounded-xl bg-surface p-6 text-foreground shadow-md"
               >
                 <p className="text-lg font-semibold">What other firms drag you through</p>
-                <p className="text-sm text-charcoal">Extras you don&rsquo;t actually need</p>
+                <p className="text-sm text-foreground">Extras you don&rsquo;t actually need</p>
                 <div className="pt-2">
                   <a
                     href="/webdev-landing"
                     data-event="cta-social-proof"
-                    className="inline-block rounded-full bg-gradient-to-r from-[var(--color-accent)] to-[var(--color-accent-dark)] px-4 py-2 text-xs font-semibold text-silver shadow transition hover:scale-105"
+                    className="inline-block rounded-full bg-gradient-to-r from-accent to-accent px-4 py-2 text-xs font-semibold text-foreground shadow transition hover:scale-105"
                   >
                     Break free
                   </a>
@@ -272,38 +272,38 @@ export default function WhyNprPage() {
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
                 transition={{ duration: 0.6, delay: 0.1 }}
-                className="space-y-2 rounded-xl bg-antique p-6 text-charcoal shadow-md"
+                className="space-y-2 rounded-xl bg-surface p-6 text-foreground shadow-md"
               >
                 <p className="text-lg font-semibold">How we keep projects moving</p>
-                <p className="text-sm text-charcoal">The NPR no-bloat process</p>
+                <p className="text-sm text-foreground">The NPR no-bloat process</p>
                 <div className="pt-2">
                   <a
                     href={Routes.contact}
                     data-event="cta-service"
-                    className="inline-block rounded-full bg-gradient-to-r from-[var(--color-accent)] to-[var(--color-accent-dark)] px-4 py-2 text-xs font-semibold text-silver shadow transition hover:scale-105"
+                    className="inline-block rounded-full bg-gradient-to-r from-accent to-accent px-4 py-2 text-xs font-semibold text-foreground shadow transition hover:scale-105"
                   >
                     Start winning
                   </a>
                 </div>
                 <ul className="space-y-1 text-sm">
                   <li className="flex items-start gap-2">
-                    <CheckCircle2 className="h-4 w-4 text-[var(--color-accent)]" />
+                    <CheckCircle2 className="h-4 w-4 text-accent" />
                     <span>Production-grade homepage</span>
                   </li>
                   <li className="flex items-start gap-2">
-                    <CheckCircle2 className="h-4 w-4 text-[var(--color-accent)]" />
+                    <CheckCircle2 className="h-4 w-4 text-accent" />
                     <span>9-section CMS site</span>
                   </li>
                   <li className="flex items-start gap-2">
-                    <CheckCircle2 className="h-4 w-4 text-[var(--color-accent)]" />
+                    <CheckCircle2 className="h-4 w-4 text-accent" />
                     <span>SOP-aligned builds</span>
                   </li>
                   <li className="flex items-start gap-2">
-                    <CheckCircle2 className="h-4 w-4 text-[var(--color-accent)]" />
+                    <CheckCircle2 className="h-4 w-4 text-accent" />
                     <span>Real-time revisions</span>
                   </li>
                   <li className="flex items-start gap-2">
-                    <CheckCircle2 className="h-4 w-4 text-[var(--color-accent)]" />
+                    <CheckCircle2 className="h-4 w-4 text-accent" />
                     <span>Vercel-level hosting</span>
                   </li>
                 </ul>
@@ -316,15 +316,15 @@ export default function WhyNprPage() {
               <a
                 href="/webdev-landing"
                 data-event="cta-social-proof"
-                className="inline-block rounded-full bg-gradient-to-r from-[var(--color-accent)] to-[var(--color-accent-dark)] px-6 py-3 text-sm font-semibold text-silver shadow-md ring-1 ring-umber/20 transition hover:scale-105"
+                className="inline-block rounded-full bg-gradient-to-r from-accent to-accent px-6 py-3 text-sm font-semibold text-foreground shadow-md ring-1 ring-umber/20 transition hover:scale-105"
               >
                 This time, don’t settle.
               </a>
             </div>
-            <ScrollCue href="#footer" className="mx-auto mt-4 text-[var(--color-accent)]" />
+            <ScrollCue href="#footer" className="mx-auto mt-4 text-accent" />
           </div>
         </section>
-        <WaveDivider flip className="text-silver" />
+        <WaveDivider flip className="text-foreground" />
       </main>
       <FinalCTA />
       <FooterSection />

--- a/src/components/CTAButton.tsx
+++ b/src/components/CTAButton.tsx
@@ -8,7 +8,7 @@ interface CTAButtonProps {
   className?: string;
 }
 
-export default function CTAButton({ href, children, event, className = 'inline-flex items-center justify-center rounded-full bg-blood px-6 py-3 text-sm font-semibold text-silver shadow-md transition hover:scale-105 hover:bg-crimson' }: CTAButtonProps) {
+export default function CTAButton({ href, children, event, className = 'inline-flex items-center justify-center rounded-full bg-primary px-6 py-3 text-sm font-semibold text-foreground shadow-md transition hover:scale-105 hover:bg-primary/90' }: CTAButtonProps) {
   return (
     <Link href={href} data-event={event} className={className}>
       {children}

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -111,9 +111,9 @@ export default function ContactForm({ onSuccess }: ContactFormProps) {
   };
 
   const inputBase =
-    'w-full rounded-md bg-antique px-10 py-3 text-sm text-charcoal shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blood/40';
+    'w-full rounded-md bg-surface px-10 py-3 text-sm text-foreground shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40';
 
-  const iconBase = 'absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-olive';
+  const iconBase = 'absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted';
 
   return (
     <motion.form
@@ -122,7 +122,7 @@ export default function ContactForm({ onSuccess }: ContactFormProps) {
       initial={{ opacity: 0, y: 30 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.6 }}
-      className="space-y-6 rounded-2xl bg-antique/80 p-6 shadow-xl ring-1 shadow-umber/20 ring-transparent backdrop-blur-md hover:ring-blood/40"
+      className="space-y-6 rounded-2xl bg-surface/80 p-6 shadow-xl ring-1 shadow-muted/20 ring-transparent backdrop-blur-md hover:ring-primary/40"
     >
       <motion.div
         className="relative"
@@ -143,7 +143,7 @@ export default function ContactForm({ onSuccess }: ContactFormProps) {
           aria-invalid={!!errors.name}
         />
         {placeholders.name && (
-          <span className="pointer-events-none absolute top-1/2 left-10 -translate-y-1/2 text-sm text-silver">
+          <span className="pointer-events-none absolute top-1/2 left-10 -translate-y-1/2 text-sm text-foreground">
             {placeholders.name}
           </span>
         )}
@@ -167,7 +167,7 @@ export default function ContactForm({ onSuccess }: ContactFormProps) {
           aria-invalid={!!errors.email}
         />
         {placeholders.email && (
-          <span className="pointer-events-none absolute top-1/2 left-10 -translate-y-1/2 text-sm text-silver">
+          <span className="pointer-events-none absolute top-1/2 left-10 -translate-y-1/2 text-sm text-foreground">
             {placeholders.email}
           </span>
         )}
@@ -196,7 +196,7 @@ export default function ContactForm({ onSuccess }: ContactFormProps) {
           <option value="Not Sure">Not Sure</option>
         </select>
         {!form.budget && (
-          <span className="pointer-events-none absolute top-1/2 left-10 -translate-y-1/2 text-sm text-silver">
+          <span className="pointer-events-none absolute top-1/2 left-10 -translate-y-1/2 text-sm text-foreground">
             Budget
           </span>
         )}
@@ -220,7 +220,7 @@ export default function ContactForm({ onSuccess }: ContactFormProps) {
           aria-invalid={!!errors.summary}
         />
         {placeholders.summary && (
-          <span className="pointer-events-none absolute top-1/2 left-10 -translate-y-1/2 text-sm text-silver">
+          <span className="pointer-events-none absolute top-1/2 left-10 -translate-y-1/2 text-sm text-foreground">
             {placeholders.summary}
           </span>
         )}
@@ -248,7 +248,7 @@ export default function ContactForm({ onSuccess }: ContactFormProps) {
           <option value="Other">Other</option>
         </select>
         {!form.referral && (
-          <span className="pointer-events-none absolute top-1/2 left-10 -translate-y-1/2 text-sm text-silver">
+          <span className="pointer-events-none absolute top-1/2 left-10 -translate-y-1/2 text-sm text-foreground">
             How did you hear about us?
           </span>
         )}
@@ -257,7 +257,7 @@ export default function ContactForm({ onSuccess }: ContactFormProps) {
         type="submit"
         whileHover={{ scale: !loading && !success ? 1.04 : 1 }}
         disabled={loading}
-        className="relative flex w-full items-center justify-center gap-2 rounded-xl bg-blood py-3 font-semibold text-silver shadow-md ring-2 ring-blood/50 transition-transform hover:shadow-lg disabled:opacity-60"
+        className="relative flex w-full items-center justify-center gap-2 rounded-xl bg-primary py-3 font-semibold text-foreground shadow-md ring-2 ring-primary/50 transition-transform hover:shadow-lg disabled:opacity-60"
       >
         {loading ? (
           <span className="h-5 w-5 animate-spin rounded-full border-2 border-silver border-t-transparent" />
@@ -267,7 +267,7 @@ export default function ContactForm({ onSuccess }: ContactFormProps) {
           'Send Message'
         )}
       </motion.button>
-      <div className="space-y-1 text-center text-xs text-charcoal">
+      <div className="space-y-1 text-center text-xs text-foreground">
         <p>No spam. No obligation. Just clarity.</p>
         <p>Trusted by 25+ SaaS, DTC, and consulting brands</p>
       </div>
@@ -275,7 +275,7 @@ export default function ContactForm({ onSuccess }: ContactFormProps) {
         <motion.div
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
-          className="text-center text-sm text-blood"
+          className="text-center text-sm text-primary"
         >
           We&apos;ll reach out within 1 business day.
           <div className="pt-2">
@@ -283,7 +283,7 @@ export default function ContactForm({ onSuccess }: ContactFormProps) {
               href="https://calendly.com"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-blood underline"
+              className="text-primary underline"
             >
               Book a Call
             </a>

--- a/src/components/StickyCTA.tsx
+++ b/src/components/StickyCTA.tsx
@@ -26,7 +26,7 @@ export default function StickyCTA() {
           exit={{ opacity: 0 }}
           whileHover={{ scale: 1.05 }}
           onClick={handleClick}
-          className="fixed right-4 bottom-4 z-50 flex items-center gap-2 rounded-full bg-blood px-4 py-2 text-sm font-semibold text-silver shadow-lg md:hidden hover:bg-crimson"
+          className="fixed right-4 bottom-4 z-50 flex items-center gap-2 rounded-full bg-primary px-4 py-2 text-sm font-semibold text-foreground shadow-lg md:hidden hover:bg-primary/90"
         >
           <MessageCircle className="h-4 w-4" /> Message Us
         </motion.button>

--- a/src/components/about/ValuesCarousel.tsx
+++ b/src/components/about/ValuesCarousel.tsx
@@ -84,7 +84,7 @@ export default function ValuesCarousel() {
   }, []);
 
   return (
-    <div className="relative mx-auto h-screen max-w-md overflow-hidden bg-antique">
+    <div className="relative mx-auto h-screen max-w-md overflow-hidden bg-surface">
       <div className="pointer-events-none absolute inset-x-0 top-0 z-10" style={{ height: '33%' }}>
         <div className="h-full bg-gradient-to-b from-white via-white/80 to-transparent" />
       </div>
@@ -108,10 +108,10 @@ export default function ValuesCarousel() {
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ duration: 0.4 }}
                 style={{ opacity }}
-                className="rounded-xl bg-antique p-6 text-charcoal shadow"
+                className="rounded-xl bg-surface p-6 text-foreground shadow"
               >
                 <p className="text-xl leading-snug font-bold">{slide.title}</p>
-                <p className="mt-2 text-lg leading-relaxed text-charcoal">{slide.description}</p>
+                <p className="mt-2 text-lg leading-relaxed text-foreground">{slide.description}</p>
               </motion.div>
             </section>
           );

--- a/src/components/global/Footer.tsx
+++ b/src/components/global/Footer.tsx
@@ -7,7 +7,7 @@ export default function Footer() {
   return (
     <footer
       id="footer"
-      className="border-t bg-[var(--color-bg-dark)] px-[clamp(1rem,4vw,3rem)] py-[clamp(2.5rem,6vw,4rem)] text-center text-[clamp(0.75rem,1vw,0.875rem)] text-[var(--color-text-light)]"
+      className="border-t bg-background px-[clamp(1rem,4vw,3rem)] py-[clamp(2.5rem,6vw,4rem)] text-center text-[clamp(0.75rem,1vw,0.875rem)] text-foreground"
     >
       <div className="mx-auto max-w-6xl space-y-8">
         <div className="space-y-4">

--- a/src/components/global/Header.tsx
+++ b/src/components/global/Header.tsx
@@ -25,7 +25,7 @@ export default function StickyHeader({ light = false }: HeaderProps) {
     return () => window.removeEventListener('scroll', onScroll);
   }, []);
 
-  const textColor = scrolled || !light ? 'text-[var(--color-text-light)]' : 'text-charcoal';
+  const textColor = scrolled || !light ? 'text-foreground' : 'text-foreground';
 
   return (
     <motion.header
@@ -33,12 +33,11 @@ export default function StickyHeader({ light = false }: HeaderProps) {
       animate={{ y: 0, opacity: 1 }}
       transition={{ duration: 0.6 }}
       className={`fixed top-0 left-0 z-50 w-full transition-all ${
-        scrolled ? 'bg-[#0A0F1C]/90 shadow-md backdrop-blur-sm' : 'backdrop-blur-0 bg-transparent'
+        scrolled ? 'bg-background/90 shadow-md backdrop-blur-sm' : 'backdrop-blur-0 bg-transparent'
       } ${textColor}`}
     >
       <div
-        className={`mx-auto flex h-[clamp(3rem,6vw,3.75rem)] w-full items-center justify-between px-3 md:px-10 lg:px-60 ${textColor}`}
-        style={{ backgroundColor: scrolled ? 'var(--color-bg-dark)' : 'transparent' }}
+        className={`mx-auto flex h-[clamp(3rem,6vw,3.75rem)] w-full items-center justify-between px-3 md:px-10 lg:px-60 ${textColor} ${scrolled ? 'bg-background' : 'bg-transparent'}`}
       >
         <Link
           href="/"
@@ -49,38 +48,38 @@ export default function StickyHeader({ light = false }: HeaderProps) {
         <nav className="hidden items-center gap-[clamp(1.25rem,3vw,2rem)] md:flex">
           <Link
             href="/pricing"
-            className="text-[clamp(0.75rem,1vw,0.875rem)] transition-transform hover:scale-105 hover:text-blood"
+            className="text-[clamp(0.75rem,1vw,0.875rem)] transition-transform hover:scale-105 hover:text-primary"
           >
             Pricing
           </Link>
           <Link
             href="/about"
-            className="text-[clamp(0.75rem,1vw,0.875rem)] transition-transform hover:scale-105 hover:text-blood"
+            className="text-[clamp(0.75rem,1vw,0.875rem)] transition-transform hover:scale-105 hover:text-primary"
           >
             About
           </Link>
           <Link
             href={Routes.contact}
-            className="text-[clamp(0.75rem,1vw,0.875rem)] transition-transform hover:scale-105 hover:text-blood"
+            className="text-[clamp(0.75rem,1vw,0.875rem)] transition-transform hover:scale-105 hover:text-primary"
           >
             Contact
           </Link>
           <Link
             href="/blog"
-            className="text-[clamp(0.75rem,1vw,0.875rem)] transition-transform hover:scale-105 hover:text-blood"
+            className="text-[clamp(0.75rem,1vw,0.875rem)] transition-transform hover:scale-105 hover:text-primary"
           >
             Blog
           </Link>
           <Link
             href="/why-npr"
-            className="text-[clamp(0.75rem,1vw,0.875rem)] transition-transform hover:scale-105 hover:text-blood"
+            className="text-[clamp(0.75rem,1vw,0.875rem)] transition-transform hover:scale-105 hover:text-primary"
           >
             Why NPR
           </Link>
           <CTAButton
             href="/webdev-landing"
             event="cta-navbar"
-            className="ml-4 inline-flex items-center gap-2 rounded-lg bg-blood px-4 py-[0.45rem] text-[clamp(0.65rem,0.9vw,0.75rem)] font-semibold text-silver shadow transition-transform hover:scale-105 hover:bg-crimson"
+            className="ml-4 inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-[0.45rem] text-[clamp(0.65rem,0.9vw,0.75rem)] font-semibold text-foreground shadow transition-transform hover:scale-105 hover:bg-primary/90"
           >
             Get Started →
           </CTAButton>

--- a/src/components/homepage/ContactSection.tsx
+++ b/src/components/homepage/ContactSection.tsx
@@ -11,37 +11,37 @@ export default function ContactSection() {
   return (
     <section
       id="contact"
-      className="relative border-t bg-[var(--color-bg-dark)] text-[var(--color-text-light)] py-[clamp(5rem,10vw,8rem)] px-[clamp(1rem,4vw,3rem)] overflow-hidden"
+      className="relative border-t bg-background text-foreground py-[clamp(5rem,10vw,8rem)] px-[clamp(1rem,4vw,3rem)] overflow-hidden"
     >
       <div className="absolute inset-0 -z-10 pointer-events-none">
-        <div className="absolute left-1/2 top-0 h-64 w-64 -translate-x-1/2 rounded-full bg-[var(--color-accent)] opacity-20 blur-3xl" />
+        <div className="absolute left-1/2 top-0 h-64 w-64 -translate-x-1/2 rounded-full bg-accent opacity-20 blur-3xl" />
       </div>
       <div className="mx-auto max-w-2xl text-center space-y-6">
         <h2 className="text-[clamp(1.75rem,3.5vw,2.5rem)] font-bold">{title}</h2>
-        <p className="text-[clamp(0.9rem,1.6vw,1.125rem)] text-silver">{subtitle}</p>
+        <p className="text-[clamp(0.9rem,1.6vw,1.125rem)] text-foreground">{subtitle}</p>
         <div className="pt-4">
           <Link
             href={cta.href}
             data-event="cta-final"
-            className="inline-flex items-center justify-center gap-2 rounded-full bg-antique px-[clamp(1.25rem,3vw,1.5rem)] py-[clamp(0.6rem,1.2vw,0.75rem)] text-[clamp(0.8rem,1vw,0.9rem)] font-semibold text-charcoal shadow-lg transition hover:scale-105 hover:bg-sepia"
+            className="inline-flex items-center justify-center gap-2 rounded-full bg-surface px-[clamp(1.25rem,3vw,1.5rem)] py-[clamp(0.6rem,1.2vw,0.75rem)] text-[clamp(0.8rem,1vw,0.9rem)] font-semibold text-foreground shadow-lg transition hover:scale-105 hover:bg-muted"
           >
             {cta.label}
             <ArrowRight className="h-4 w-4" />
           </Link>
         </div>
-        <p className="text-sm text-silver">{trust}</p>
-        {urgency && <p className="text-xs font-medium text-[var(--color-accent)]">{urgency}</p>}
+        <p className="text-sm text-foreground">{trust}</p>
+        {urgency && <p className="text-xs font-medium text-accent">{urgency}</p>}
         <div className="pt-2">
           <Link
             href={exitLink.href}
-            className="text-[clamp(0.75rem,1vw,0.875rem)] text-silver underline-offset-4 hover:underline"
+            className="text-[clamp(0.75rem,1vw,0.875rem)] text-foreground underline-offset-4 hover:underline"
           >
             {exitLink.label}
           </Link>
         </div>
       </div>
       <motion.div
-        className="absolute bottom-2 right-2 text-[var(--color-accent)]"
+        className="absolute bottom-2 right-2 text-accent"
         animate={{ y: [0, -10, 0] }}
         transition={{ duration: 2, repeat: Infinity }}
       >

--- a/src/components/homepage/Hero.tsx
+++ b/src/components/homepage/Hero.tsx
@@ -116,7 +116,7 @@ const HeroSection: React.FC<HeroProps> = ({ headline, subheadline, ctaText, ctaL
       id="hero"
       ref={heroRef}
       aria-label="Hero Section"
-      className="relative min-h-screen pb-[5vh] flex items-center justify-center bg-[var(--color-bg-dark)] font-sans overflow-hidden"
+      className="relative min-h-screen pb-[5vh] flex items-center justify-center bg-background font-sans overflow-hidden"
     >
       <div
         ref={containerRef}
@@ -133,7 +133,7 @@ const HeroSection: React.FC<HeroProps> = ({ headline, subheadline, ctaText, ctaL
         <motion.div
           variants={textVariants}
           custom={0}
-          className="ml-[10vw] mb-6 text-[clamp(0.85rem,1.2vw,0.9rem)] font-thin tracking-widest text-[var(--color-accent)]"
+          className="ml-[10vw] mb-6 text-[clamp(0.85rem,1.2vw,0.9rem)] font-thin tracking-widest text-accent"
         >
           HELLO, WE ARE NPR MEDIA
         </motion.div>
@@ -160,12 +160,12 @@ const HeroSection: React.FC<HeroProps> = ({ headline, subheadline, ctaText, ctaL
               custom={2}
               className="group relative inline-block hover:scale-105"
             >
-              <div className="bg-blood/20 absolute -inset-1.5 z-[-1] animate-pulse rounded-full" />
+              <div className="bg-primary/20 absolute -inset-1.5 z-[-1] animate-pulse rounded-full" />
               <Link
                 ref={ctaRef}
                 href={ctaLink}
                 data-event="cta-hero"
-                className="inline-flex items-center justify-center rounded-full px-4 py-[0.4rem] text-[clamp(0.7rem,1vw,0.9rem)] font-semibold text-silver shadow-lg ring-1 bg-blood transition hover:bg-crimson"
+                className="inline-flex items-center justify-center rounded-full px-4 py-[0.4rem] text-[clamp(0.7rem,1vw,0.9rem)] font-semibold text-foreground shadow-lg ring-1 bg-primary transition hover:bg-primary/90"
               >
                 {ctaText}
               </Link>
@@ -194,7 +194,7 @@ const HeroSection: React.FC<HeroProps> = ({ headline, subheadline, ctaText, ctaL
               style={{ fontSize: 'min(48vh,32vw)' }}
               variants={{ hidden: { opacity: 0, y: -20 }, visible: { opacity: 0.6, y: 0 } }}
               transition={{ duration: 0.6 }}
-              className="block font-extrabold text-[var(--color-accent)] leading-none"
+              className="block font-extrabold text-accent leading-none"
             >
               {letter}
             </motion.span>
@@ -233,13 +233,13 @@ const HeroSection: React.FC<HeroProps> = ({ headline, subheadline, ctaText, ctaL
       </motion.div>
 
       <div className="absolute bottom-6 left-1/2 z-10 -translate-x-1/2 transform">
-        <div className="text-blood animate-bounce text-lg drop-shadow-[0_0_4px_rgba(255,255,255,0.5)]">
+        <div className="text-primary animate-bounce text-lg drop-shadow-[0_0_4px_rgba(255,255,255,0.5)]">
           ↓
         </div>
       </div>
 
       {isStickyVisible && (
-        <div className="fixed bottom-36 left-1/2 z-50 -translate-x-1/2 rounded-full bg-blood px-4 py-2 text-sm font-bold text-silver opacity-90 shadow-xl hover:scale-105 hover:bg-crimson">
+        <div className="fixed bottom-36 left-1/2 z-50 -translate-x-1/2 rounded-full bg-primary px-4 py-2 text-sm font-bold text-foreground opacity-90 shadow-xl hover:scale-105 hover:bg-primary/90">
           Still thinking? Start your free trial now →
         </div>
       )}

--- a/src/components/homepage/IndustryTemplates.tsx
+++ b/src/components/homepage/IndustryTemplates.tsx
@@ -13,14 +13,14 @@ export default function IndustryTemplatesSection() {
   return (
     <section
       id="templates"
-      className="w-full scroll-mt-[120px] overflow-x-hidden bg-antique text-charcoal py-[clamp(5rem,10vw,8rem)]"
+      className="w-full scroll-mt-[120px] overflow-x-hidden bg-surface text-foreground py-[clamp(5rem,10vw,8rem)]"
     >
       <div className="container mx-auto max-w-4xl px-4 sm:px-6 lg:px-8">
         <div className="mb-12 text-center">
-          <h2 className="text-charcoal text-[clamp(1.75rem,3.5vw,2.5rem)] font-bold tracking-tight">
+          <h2 className="text-foreground text-[clamp(1.75rem,3.5vw,2.5rem)] font-bold tracking-tight">
             Authority Platform Demo
           </h2>
-          <p className="text-charcoal mt-2 text-[clamp(0.9rem,1.6vw,1.125rem)]">
+          <p className="text-foreground mt-2 text-[clamp(0.9rem,1.6vw,1.125rem)]">
             Our premier template for coaches and consultants.
           </p>
         </div>
@@ -44,13 +44,13 @@ export default function IndustryTemplatesSection() {
           <div
             className="flex flex-grow flex-col md:w-1/2 origin-left transform-gpu transition-all duration-500 group-hover:[transform:translateX(1.5rem)_rotateY(-6deg)]"
           >
-            <h4 className="text-charcoal mb-1 truncate text-[clamp(1rem,1.8vw,1.25rem)] font-semibold">
+            <h4 className="text-foreground mb-1 truncate text-[clamp(1rem,1.8vw,1.25rem)] font-semibold">
               {authority.title}
             </h4>
-            <p className="text-charcoal mb-1 text-[clamp(0.8rem,1.2vw,0.9rem)]">
+            <p className="text-foreground mb-1 text-[clamp(0.8rem,1.2vw,0.9rem)]">
               {authority.description}
             </p>
-            <p className="text-charcoal mb-3 text-[clamp(0.7rem,1vw,0.8rem)] italic">
+            <p className="text-foreground mb-3 text-[clamp(0.7rem,1vw,0.8rem)] italic">
               Used by 12+ clients in this industry
             </p>
             <div className="mt-auto text-[clamp(0.8rem,1vw,0.9rem)] font-medium">
@@ -60,7 +60,7 @@ export default function IndustryTemplatesSection() {
                 rel="noopener noreferrer"
                 title="Opens in new tab"
                 aria-label={`Open demo for ${authority.title}`}
-                className="bg-[var(--color-accent)] text-silver hover:bg-[var(--color-accent-dark)] focus:ring-[var(--color-accent)] rounded-full px-[clamp(0.75rem,2vw,1rem)] py-[clamp(0.4rem,1vw,0.6rem)] transition hover:scale-105 focus:ring-2 focus:outline-none"
+                className="bg-accent text-foreground hover:bg-accent focus:ring-accent rounded-full px-[clamp(0.75rem,2vw,1rem)] py-[clamp(0.4rem,1vw,0.6rem)] transition hover:scale-105 focus:ring-2 focus:outline-none"
               >
                 Open Demo →
               </a>

--- a/src/components/homepage/PricingSection.tsx
+++ b/src/components/homepage/PricingSection.tsx
@@ -9,14 +9,14 @@ export default function PricingSection() {
   return (
     <section
       id="pricing"
-      className="w-full border-t bg-[var(--color-bg-dark)] text-[var(--color-text-light)] py-[clamp(5rem,10vw,8rem)]"
+      className="w-full border-t bg-background text-foreground py-[clamp(5rem,10vw,8rem)]"
     >
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <div className="mx-auto max-w-4xl space-y-4 text-center">
           <h2 className="text-[clamp(1.75rem,3.5vw,2.5rem)] font-bold tracking-tight">
             Our Packages
           </h2>
-          <p className="text-[clamp(0.9rem,1.6vw,1.125rem)] text-silver">
+          <p className="text-[clamp(0.9rem,1.6vw,1.125rem)] text-foreground">
             {pricing.headline}
           </p>
         </div>
@@ -29,7 +29,7 @@ export default function PricingSection() {
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               transition={{ duration: 0.6, delay: index * 0.1 }}
-              className={`relative flex flex-col overflow-hidden rounded-2xl border border-[var(--color-olive)] bg-[var(--color-card)] p-6 ${tier.highlight ? 'ring-2 ring-[var(--color-accent)]' : ''}`}
+              className={`relative flex flex-col overflow-hidden rounded-2xl border border-muted bg-surface p-6 ${tier.highlight ? 'ring-2 ring-accent' : ''}`}
             >
               {tier.highlight && (
                 <motion.div
@@ -46,23 +46,23 @@ export default function PricingSection() {
                 <h3 className="text-[clamp(1rem,1.8vw,1.25rem)] font-semibold">
                   {tier.title}
                 </h3>
-                <span className="text-[clamp(1rem,1.8vw,1.25rem)] font-bold text-[var(--color-text-light)]">
+                <span className="text-[clamp(1rem,1.8vw,1.25rem)] font-bold text-foreground">
                   {tier.price}
                 </span>
               </div>
-              <p className="mt-1 text-[clamp(0.8rem,1.2vw,0.9rem)] italic text-[var(--color-text-light)]">
+              <p className="mt-1 text-[clamp(0.8rem,1.2vw,0.9rem)] italic text-foreground">
                 {tier.microcopy}
               </p>
-              <p className="mt-2 text-[clamp(0.8rem,1.2vw,0.9rem)] text-[var(--color-text-light)]">
+              <p className="mt-2 text-[clamp(0.8rem,1.2vw,0.9rem)] text-foreground">
                 {tier.description}
               </p>
-              <ul className="mt-4 flex-1 space-y-1 text-[clamp(0.8rem,1.2vw,0.9rem)] text-[var(--color-text-light)]">
+              <ul className="mt-4 flex-1 space-y-1 text-[clamp(0.8rem,1.2vw,0.9rem)] text-foreground">
                 {tier.features.map((feature, i) => (
                   <li
                     key={i}
-                    className={i === 0 ? 'font-semibold text-silver' : ''}
+                    className={i === 0 ? 'font-semibold text-foreground' : ''}
                   >
-                    <span className="mr-1 text-[var(--color-accent)]">
+                    <span className="mr-1 text-accent">
                       {i === 0 ? '✅' : '✓'}
                     </span>
                     {feature}
@@ -73,7 +73,7 @@ export default function PricingSection() {
                 <Link
                   href="/contact"
                   data-event="cta-pricing"
-                  className="block w-full rounded-full border border-[var(--color-olive)] bg-[var(--color-bg-dark)] px-[clamp(1rem,2.5vw,1.25rem)] py-[clamp(0.6rem,1.2vw,0.75rem)] text-center text-[clamp(0.8rem,1vw,0.9rem)] font-medium text-[var(--color-text-light)] shadow-sm transition hover:scale-105 hover:bg-[var(--color-olive)]"
+                  className="block w-full rounded-full border border-muted bg-background px-[clamp(1rem,2.5vw,1.25rem)] py-[clamp(0.6rem,1.2vw,0.75rem)] text-center text-[clamp(0.8rem,1vw,0.9rem)] font-medium text-foreground shadow-sm transition hover:scale-105 hover:bg-muted"
                 >
                   {tier.cta}
                 </Link>

--- a/src/components/homepage/QuoteModal.tsx
+++ b/src/components/homepage/QuoteModal.tsx
@@ -19,23 +19,23 @@ export default function QuoteModal({
   return (
     <Dialog.Root onOpenChange={() => setSubmitted(false)}>
       <Dialog.Trigger asChild>
-        <button className="inline-flex items-center justify-center rounded-full bg-antique px-6 py-2 text-sm font-semibold text-charcoal shadow hover:bg-sepia">
+        <button className="inline-flex items-center justify-center rounded-full bg-surface px-6 py-2 text-sm font-semibold text-foreground shadow hover:bg-muted">
           {triggerLabel}
         </button>
       </Dialog.Trigger>
       <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 bg-umber/80" />
-        <Dialog.Content className="fixed top-1/2 left-1/2 w-[90vw] max-w-md -translate-x-1/2 -translate-y-1/2 rounded-xl bg-antique p-6 text-charcoal shadow-lg">
+        <Dialog.Overlay className="fixed inset-0 bg-muted/80" />
+        <Dialog.Content className="fixed top-1/2 left-1/2 w-[90vw] max-w-md -translate-x-1/2 -translate-y-1/2 rounded-xl bg-surface p-6 text-foreground shadow-lg">
           <Dialog.Title className="text-lg font-semibold">Tell us what you need</Dialog.Title>
-          <Dialog.Description className="text-sm text-charcoal">
+          <Dialog.Description className="text-sm text-foreground">
             Your submission is reviewed by our founder — not a sales bot.
           </Dialog.Description>
-          <Dialog.Close className="absolute right-3 top-3 rounded p-1 text-charcoal hover:bg-sepia">
+          <Dialog.Close className="absolute right-3 top-3 rounded p-1 text-foreground hover:bg-muted">
             <X className="h-4 w-4" />
           </Dialog.Close>
           {submitted ? (
             <div className="mt-4 flex flex-col items-center space-y-2">
-              <CheckCircle2 className="h-8 w-8 text-blood" />
+              <CheckCircle2 className="h-8 w-8 text-primary" />
               <p className="text-center text-sm">We&apos;ll respond within 24h with next steps.</p>
             </div>
           ) : (
@@ -73,7 +73,7 @@ export default function QuoteModal({
                 Details
                 <textarea className="mt-1 w-full rounded border px-2 py-1" rows={3} required></textarea>
               </label>
-              <button type="submit" className="mt-2 w-full rounded bg-blood px-4 py-2 text-silver hover:bg-crimson">
+              <button type="submit" className="mt-2 w-full rounded bg-primary px-4 py-2 text-foreground hover:bg-primary/90">
                 Send Request
               </button>
             </form>

--- a/src/components/sections/FinalCTA.tsx
+++ b/src/components/sections/FinalCTA.tsx
@@ -2,7 +2,7 @@ import { Routes } from '@/lib/routes';
 
 export default function FinalCTA() {
   return (
-    <section className="bg-umber px-6 py-20 text-center text-silver">
+    <section className="bg-muted px-6 py-20 text-center text-foreground">
       <h2 className="mb-4 text-3xl font-bold md:text-4xl">Let’s build something legendary</h2>
       <p className="mx-auto mb-6 max-w-2xl text-lg">
         We craft websites that drive serious results. Book your strategy call today.
@@ -10,11 +10,11 @@ export default function FinalCTA() {
       <a
         href={Routes.contact}
         data-event="cta-final"
-        className="inline-block rounded-lg bg-blood px-6 py-3 font-semibold text-silver transition hover:bg-crimson"
+        className="inline-block rounded-lg bg-primary px-6 py-3 font-semibold text-foreground transition hover:bg-primary/90"
       >
         Book Free Discovery Call
       </a>
-      <p className="mt-4 text-sm text-silver">No pressure. Just clarity and next steps.</p>
+      <p className="mt-4 text-sm text-foreground">No pressure. Just clarity and next steps.</p>
     </section>
   );
 }

--- a/src/components/webdevLanding/CTASection.tsx
+++ b/src/components/webdevLanding/CTASection.tsx
@@ -4,7 +4,7 @@ import MiniForm from './MiniForm'
 
 export default function CTASection() {
   return (
-    <section id="cta" className="relative bg-gradient-to-br from-umber via-blood to-crimson py-24 text-silver">
+    <section id="cta" className="relative bg-gradient-to-br from-muted via-accent to-accent/90 py-24 text-foreground">
       <div className="mx-auto grid max-w-7xl grid-cols-1 gap-12 px-6 md:px-12 lg:px-20 md:grid-cols-2">
         <motion.div
           initial={{ opacity: 0, y: 20 }}
@@ -15,12 +15,12 @@ export default function CTASection() {
         >
           <h2 className="text-[clamp(2rem,5vw,3rem)] font-bold">Get Your Free Strategy Mockup</h2>
           <p className="text-[clamp(1rem,2vw,1.25rem)]">Share your goals and we’ll map a high-converting website approach—free.</p>
-          <ul className="list-disc pl-5 text-sm marker:text-silver">
+          <ul className="list-disc pl-5 text-sm marker:text-foreground">
             <li>Actionable page-level insights</li>
             <li>Senior dev & design expertise</li>
             <li>100% obligation-free</li>
           </ul>
-          <p className="text-sm text-silver">Prefer to schedule a call? <a href="https://calendly.com" target="_blank" className="underline">Book via Calendly</a></p>
+          <p className="text-sm text-foreground">Prefer to schedule a call? <a href="https://calendly.com" target="_blank" className="underline">Book via Calendly</a></p>
         </motion.div>
         <MiniForm />
       </div>

--- a/src/components/webdevLanding/Hero.tsx
+++ b/src/components/webdevLanding/Hero.tsx
@@ -14,7 +14,7 @@ const textVariants = {
 
 export default function Hero({ headline, subheadline, cta }: HeroProps) {
   return (
-    <section className="relative flex min-h-screen flex-col items-center justify-center overflow-hidden bg-gradient-to-br from-umber via-blood to-crimson text-center text-silver">
+    <section className="relative flex min-h-screen flex-col items-center justify-center overflow-hidden bg-gradient-to-br from-muted via-accent to-accent/90 text-center text-foreground">
       <motion.div
         initial="hidden"
         whileInView="visible"
@@ -38,7 +38,7 @@ export default function Hero({ headline, subheadline, cta }: HeroProps) {
           variants={textVariants}
           href="#cta"
           data-event="webdev-scroll-trigger"
-          className="mt-8 inline-block rounded-full bg-antique px-6 py-3 font-semibold text-charcoal shadow-lg ring-1 ring-silver/20 transition hover:scale-105 hover:bg-sepia"
+          className="mt-8 inline-block rounded-full bg-surface px-6 py-3 font-semibold text-foreground shadow-lg ring-1 ring-muted/20 transition hover:scale-105 hover:bg-muted"
         >
           {cta}
         </motion.a>

--- a/src/components/webdevLanding/MiniForm.tsx
+++ b/src/components/webdevLanding/MiniForm.tsx
@@ -21,9 +21,9 @@ export default function MiniForm() {
     setTimeout(() => setSuccess(false), 2500)
   }
 
-  const baseInput = 'peer w-full rounded-md bg-antique/80 px-10 py-3 text-sm text-charcoal shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blood/40 placeholder-transparent'
-  const iconBase = 'absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-olive pointer-events-none'
-  const labelBase = 'pointer-events-none absolute left-10 top-1/2 -translate-y-1/2 text-sm text-silver transition-all peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2 peer-focus:top-2 peer-focus:-translate-y-0 peer-focus:text-xs'
+  const baseInput = 'peer w-full rounded-md bg-surface/80 px-10 py-3 text-sm text-foreground shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 placeholder-transparent'
+  const iconBase = 'absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted pointer-events-none'
+  const labelBase = 'pointer-events-none absolute left-10 top-1/2 -translate-y-1/2 text-sm text-foreground transition-all peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2 peer-focus:top-2 peer-focus:-translate-y-0 peer-focus:text-xs'
 
   return (
     <motion.form
@@ -32,7 +32,7 @@ export default function MiniForm() {
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true }}
       transition={{ duration: 0.6, delay: 0.2 }}
-      className="space-y-4 rounded-2xl bg-antique/20 p-6 shadow-xl ring-1 ring-silver/20 backdrop-blur"
+      className="space-y-4 rounded-2xl bg-surface/20 p-6 shadow-xl ring-1 ring-muted/20 backdrop-blur"
     >
       <div className="relative">
         <User className={iconBase} />
@@ -65,11 +65,11 @@ export default function MiniForm() {
         data-event="webdev-cta-submit"
         whileHover={{ scale: !loading && !success ? 1.05 : 1 }}
         disabled={loading || success}
-        className="relative flex w-full items-center justify-center gap-2 rounded-xl bg-blood py-3 font-semibold text-silver shadow-md transition hover:bg-crimson"
+        className="relative flex w-full items-center justify-center gap-2 rounded-xl bg-primary py-3 font-semibold text-foreground shadow-md transition hover:bg-primary/90"
       >
         {loading ? <span className="h-5 w-5 animate-spin rounded-full border-2 border-silver border-t-transparent" /> : success ? <Check className="h-5 w-5" /> : 'Start My Mockup'}
       </motion.button>
-      {success && <p className="pt-2 text-center text-sm text-silver">We’ll be in touch shortly.</p>}
+      {success && <p className="pt-2 text-center text-sm text-foreground">We’ll be in touch shortly.</p>}
     </motion.form>
   )
 }

--- a/src/components/webdevLanding/OfferStack.tsx
+++ b/src/components/webdevLanding/OfferStack.tsx
@@ -12,7 +12,7 @@ const items = [
 
 export default function OfferStack() {
   return (
-    <section className="bg-antique py-24">
+    <section className="bg-surface py-24">
       <div className="mx-auto max-w-7xl px-6 md:px-12 lg:px-20">
         <motion.h2
           initial={{ opacity: 0, y: 20 }}
@@ -31,11 +31,11 @@ export default function OfferStack() {
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               transition={{ duration: 0.5, delay: i * 0.1 }}
-              className="rounded-2xl bg-antique/70 p-6 text-center shadow-xl ring-1 ring-umber/20 backdrop-blur-md hover:shadow-2xl"
+              className="rounded-2xl bg-surface/70 p-6 text-center shadow-xl ring-1 ring-umber/20 backdrop-blur-md hover:shadow-2xl"
             >
-              <item.icon className="mx-auto mb-3 h-6 w-6 text-blood" />
+              <item.icon className="mx-auto mb-3 h-6 w-6 text-primary" />
               <h3 className="mb-1 font-semibold text-[clamp(1rem,1.6vw,1.25rem)]">{item.label}</h3>
-              <p className="text-sm text-charcoal">{item.text}</p>
+              <p className="text-sm text-foreground">{item.text}</p>
             </motion.div>
           ))}
         </div>

--- a/src/components/webdevLanding/PainPoints.tsx
+++ b/src/components/webdevLanding/PainPoints.tsx
@@ -34,13 +34,13 @@ export default function PainPoints() {
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.5, delay: i * 0.1 }}
-            className="rounded-2xl bg-antique/60 p-6 text-center shadow-xl ring-1 ring-umber/20 backdrop-blur-md hover:shadow-2xl"
+            className="rounded-2xl bg-surface/60 p-6 text-center shadow-xl ring-1 ring-umber/20 backdrop-blur-md hover:shadow-2xl"
           >
-            <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-blood/20 text-blood">
+            <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-primary/20 text-primary">
               {p.icon}
             </div>
             <h3 className="mb-2 font-semibold text-[clamp(1.1rem,1.8vw,1.25rem)]">{p.title}</h3>
-            <p className="text-sm text-charcoal">{p.text}</p>
+            <p className="text-sm text-foreground">{p.text}</p>
           </motion.div>
         ))}
       </div>

--- a/src/components/webdevLanding/PricingPreview.tsx
+++ b/src/components/webdevLanding/PricingPreview.tsx
@@ -30,7 +30,7 @@ export default function PricingPreview() {
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           transition={{ duration: 0.6, delay: 0.2 }}
-          className="mt-8 inline-block rounded-full bg-blood px-6 py-3 font-semibold text-silver shadow-lg transition hover:scale-105 hover:bg-crimson"
+          className="mt-8 inline-block rounded-full bg-primary px-6 py-3 font-semibold text-foreground shadow-lg transition hover:scale-105 hover:bg-primary/90"
         >
           Let’s Build Your Quote
         </motion.a>
@@ -39,7 +39,7 @@ export default function PricingPreview() {
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           transition={{ duration: 0.6, delay: 0.3 }}
-          className="mt-4 text-sm text-charcoal"
+          className="mt-4 text-sm text-foreground"
         >
           We respond to every serious request within 1 business day.
         </motion.p>

--- a/src/components/webdevLanding/Proof.tsx
+++ b/src/components/webdevLanding/Proof.tsx
@@ -40,11 +40,11 @@ export default function Proof() {
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               transition={{ duration: 0.5, delay: i * 0.1 }}
-              className="rounded-2xl bg-antique/70 p-6 shadow-xl ring-1 ring-umber/20 backdrop-blur-md hover:shadow-2xl"
+              className="rounded-2xl bg-surface/70 p-6 shadow-xl ring-1 ring-umber/20 backdrop-blur-md hover:shadow-2xl"
             >
               <p className="text-sm italic">&ldquo;{t.quote}&rdquo;</p>
               <p className="mt-4 font-semibold">{t.name}</p>
-              <p className="text-xs text-charcoal">{t.title}</p>
+              <p className="text-xs text-foreground">{t.title}</p>
             </motion.div>
           ))}
         </div>

--- a/src/components/whyNpr/AiCarousel.tsx
+++ b/src/components/whyNpr/AiCarousel.tsx
@@ -66,7 +66,7 @@ export default function AiCarousel() {
                   animate={{ opacity: 1, y: 0 }}
                   exit={{ opacity: 0, y: -30 }}
                   transition={{ duration: 0.5 }}
-                  className="mx-auto w-[clamp(16rem,40vw,22rem)] space-y-4 rounded-xl border border-silver/20 bg-[var(--color-card)] p-6 text-center text-silver shadow-2xl"
+                  className="mx-auto w-[clamp(16rem,40vw,22rem)] space-y-4 rounded-xl border border-silver/20 bg-surface p-6 text-center text-foreground shadow-2xl"
                 >
                   <h2 className="text-2xl font-bold">{title}</h2>
                   <ul className="list-disc space-y-1 pl-5 text-left text-sm">
@@ -82,7 +82,7 @@ export default function AiCarousel() {
       </div>
       <ChevronDown
         style={{ bottom: '25%' }}
-        className="pointer-events-none absolute left-1/2 h-8 w-8 -translate-x-1/2 animate-bounce text-[var(--color-accent)]"
+        className="pointer-events-none absolute left-1/2 h-8 w-8 -translate-x-1/2 animate-bounce text-accent"
       />
     </div>
   )

--- a/src/components/whyNpr/FirmCarousel.tsx
+++ b/src/components/whyNpr/FirmCarousel.tsx
@@ -85,21 +85,21 @@ export default function FirmCarousel() {
                   animate={{ opacity: 1, y: 0 }}
                   exit={{ opacity: 0, y: -30 }}
                   transition={{ duration: 0.5 }}
-                  className="mx-auto w-[clamp(18rem,60vw,28rem)] rounded-xl border border-umber/20 bg-gradient-to-br from-antique via-antique to-sepia p-6 text-charcoal shadow-2xl"
+                  className="mx-auto w-[clamp(18rem,60vw,28rem)] rounded-xl border border-muted/20 bg-gradient-to-br from-surface via-surface to-muted p-6 text-foreground shadow-2xl"
                 >
                   <div className="grid grid-cols-[1fr_auto_1fr_auto_1fr] items-center gap-4">
                     <div>
-                      <p className="text-xs font-semibold text-charcoal">Other Firms</p>
+                      <p className="text-xs font-semibold text-foreground">Other Firms</p>
                       <p className="text-sm">{row.other}</p>
                     </div>
-                    <ArrowRight className="mx-auto text-olive" />
+                    <ArrowRight className="mx-auto text-muted" />
                     <div>
-                      <p className="text-xs font-semibold text-charcoal">NPR Media</p>
+                      <p className="text-xs font-semibold text-foreground">NPR Media</p>
                       <p className="text-sm">{row.npr}</p>
                     </div>
-                    <ArrowRight className="mx-auto text-olive" />
+                    <ArrowRight className="mx-auto text-muted" />
                     <div>
-                      <p className="text-xs font-semibold text-charcoal">Your Gain</p>
+                      <p className="text-xs font-semibold text-foreground">Your Gain</p>
                       <p className="text-sm">{row.gain}</p>
                     </div>
                   </div>
@@ -111,7 +111,7 @@ export default function FirmCarousel() {
       </div>
       <ChevronDown
         style={{ bottom: '25%' }}
-        className="pointer-events-none absolute left-1/2 h-8 w-8 -translate-x-1/2 animate-bounce text-[var(--color-accent)]"
+        className="pointer-events-none absolute left-1/2 h-8 w-8 -translate-x-1/2 animate-bounce text-accent"
       />
     </div>
   )

--- a/src/components/whyNpr/NprCarousel.tsx
+++ b/src/components/whyNpr/NprCarousel.tsx
@@ -65,7 +65,7 @@ export default function NprCarousel() {
                   animate={{ opacity: 1, x: 0 }}
                   exit={{ opacity: 0, x: -30 }}
                   transition={{ duration: 0.5 }}
-                  className="mx-auto w-[clamp(16rem,40vw,22rem)] space-y-4 rounded-xl border border-silver/20 bg-gradient-to-br from-[var(--color-accent)] via-crimson to-[var(--color-accent-dark)] p-6 text-center text-silver shadow-2xl"
+                  className="mx-auto w-[clamp(16rem,40vw,22rem)] space-y-4 rounded-xl border border-silver/20 bg-gradient-to-br from-accent via-accent/90 to-accent p-6 text-center text-foreground shadow-2xl"
                 >
                   <h2 className="text-2xl font-bold">{title}</h2>
                   <ul className="list-disc space-y-1 pl-5 text-left text-sm">
@@ -80,7 +80,7 @@ export default function NprCarousel() {
         ))}
       </div>
       <ChevronRight
-        className="pointer-events-none absolute right-2 top-1/2 h-8 w-8 -translate-y-1/2 animate-bounce text-[var(--color-accent)]"
+        className="pointer-events-none absolute right-2 top-1/2 h-8 w-8 -translate-y-1/2 animate-bounce text-accent"
       />
     </div>
   )


### PR DESCRIPTION
## Summary
- replace brand colors with semantic tokens
- clean up inline color styles for the header

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6864cea761b8832899221889a4049794