### PR TITLE
Purge legacy colors

### DIFF
--- a/src/components/about/ValuesCarousel.tsx
+++ b/src/components/about/ValuesCarousel.tsx
@@ -85,14 +85,17 @@ export default function ValuesCarousel() {
 
   return (
     <div className="relative mx-auto h-screen max-w-md overflow-hidden bg-olive">
-      <div className="pointer-events-none absolute inset-x-0 top-0 z-10" style={{ height: '33%' }}>
-        <div className="h-full bg-gradient-to-b from-white via-white/80 to-transparent" />
+      <div
+        className="pointer-events-none absolute inset-x-0 top-0 z-10"
+        style={{ height: '33%' }}
+      >
+        <div className="h-full bg-gradient-to-b from-antique via-antique/80 to-transparent" />
       </div>
       <div
         className="pointer-events-none absolute inset-x-0 bottom-0 z-10"
         style={{ height: '33%' }}
       >
-        <div className="h-full bg-gradient-to-t from-white via-white/80 to-transparent" />
+        <div className="h-full bg-gradient-to-t from-antique via-antique/80 to-transparent" />
       </div>
       <div
         ref={containerRef}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,19 +4,19 @@ const defaultTheme = require('tailwindcss/defaultTheme');
 module.exports = {
   content: ['./src/**/*.{js,ts,jsx,tsx,html}'],
   theme: {
+    colors: {
+      antique: '#d7c7a5',
+      sepia: '#b7a077',
+      olive: '#786c4f',
+      umber: '#3b3224',
+      silver: '#d2d2d2',
+      charcoal: '#2f2f2f',
+      blood: '#b30000',
+      crimson: '#7a0000',
+      transparent: 'transparent',
+      current: 'currentColor',
+    },
     extend: {
-      colors: {
-        antique: '#d7c7a5',
-        sepia: '#b7a077',
-        olive: '#786c4f',
-        umber: '#3b3224',
-        silver: '#d2d2d2',
-        charcoal: '#2f2f2f',
-        blood: '#b30000',
-        crimson: '#7a0000',
-        transparent: 'transparent',
-        current: 'currentColor',
-      },
 
       fontFamily: {
         didot: ['"GFS Didot"', 'serif'],


### PR DESCRIPTION
## Summary
- remove remaining white gradients
- restrict Tailwind palette to custom brand colors only

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_686b0c96edf08328996c016b61b44cb6