### PR TITLE
Revert layout spacing tweaks

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1431,14 +1431,6 @@
 }
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap');
 :root {
-  --spacing: 0.25rem;
-  --container-md: 28rem;
-  --container-xl: 36rem;
-  --container-2xl: 42rem;
-  --container-3xl: 48rem;
-  --container-4xl: 56rem;
-  --container-6xl: 72rem;
-  --container-7xl: 80rem;
   --header-height: 4rem;
   --section-padding: 6rem;
   --max-content-width: 1280px;

--- a/public/styles.css
+++ b/public/styles.css
@@ -1431,7 +1431,7 @@
 }
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap');
 :root {
-  --header-height: 4rem;
+  --header-height: 3.75rem;
   --section-padding: 6rem;
   --max-content-width: 1280px;
   --font-heading: 'Inter', sans-serif;

--- a/src/components/global/Header.tsx
+++ b/src/components/global/Header.tsx
@@ -33,11 +33,11 @@ export default function StickyHeader({ light = false }: HeaderProps) {
       animate={{ y: 0, opacity: 1 }}
       transition={{ duration: 0.6 }}
       className={`fixed top-0 left-0 z-50 w-full transition-all ${
-        scrolled ? 'bg-antique/90 shadow-md backdrop-blur-sm' : 'backdrop-blur-0 bg-transparent'
+        scrolled ? 'bg-antique/90 shadow-md backdrop-blur-sm' : 'bg-transparent backdrop-blur-0'
       } ${textColor}`}
     >
       <div
-        className={`mx-auto flex h-[clamp(3rem,6vw,3.75rem)] w-full items-center justify-between px-4 md:px-10 lg:px-20 ${textColor} ${scrolled ? 'bg-antique' : 'bg-transparent'}`}
+        className={`mx-auto flex h-[clamp(3rem,6vw,3.75rem)] w-full items-center justify-between px-3 md:px-10 lg:px-60 ${textColor} ${scrolled ? 'bg-antique' : 'bg-transparent'}`}
       >
         <Link
           href="/"
@@ -45,41 +45,41 @@ export default function StickyHeader({ light = false }: HeaderProps) {
         >
           NPR MEDIA
         </Link>
-        <nav className="hidden items-center gap-[clamp(1rem,3vw,1.75rem)] md:flex">
+        <nav className="hidden items-center gap-[clamp(1.25rem,3vw,2rem)] md:flex">
           <Link
             href="/pricing"
-            className="hover:text-blood text-[clamp(0.75rem,1vw,0.875rem)] transition-transform hover:scale-105"
+            className="text-[clamp(0.75rem,1vw,0.875rem)] transition-transform hover:scale-105 hover:text-blood"
           >
             Pricing
           </Link>
           <Link
             href="/about"
-            className="hover:text-blood text-[clamp(0.75rem,1vw,0.875rem)] transition-transform hover:scale-105"
+            className="text-[clamp(0.75rem,1vw,0.875rem)] transition-transform hover:scale-105 hover:text-blood"
           >
             About
           </Link>
           <Link
             href={Routes.contact}
-            className="hover:text-blood text-[clamp(0.75rem,1vw,0.875rem)] transition-transform hover:scale-105"
+            className="text-[clamp(0.75rem,1vw,0.875rem)] transition-transform hover:scale-105 hover:text-blood"
           >
             Contact
           </Link>
           <Link
             href="/blog"
-            className="hover:text-blood text-[clamp(0.75rem,1vw,0.875rem)] transition-transform hover:scale-105"
+            className="text-[clamp(0.75rem,1vw,0.875rem)] transition-transform hover:scale-105 hover:text-blood"
           >
             Blog
           </Link>
           <Link
             href="/why-npr"
-            className="hover:text-blood text-[clamp(0.75rem,1vw,0.875rem)] transition-transform hover:scale-105"
+            className="text-[clamp(0.75rem,1vw,0.875rem)] transition-transform hover:scale-105 hover:text-blood"
           >
             Why NPR
           </Link>
           <CTAButton
             href="/webdev-landing"
             event="cta-navbar"
-            className="bg-blood text-charcoal hover:bg-blood ml-4 inline-flex items-center gap-2 rounded-lg px-4 py-[0.45rem] text-[clamp(0.65rem,0.9vw,0.75rem)] font-semibold shadow transition-transform hover:scale-105"
+            className="ml-4 inline-flex items-center gap-2 rounded-lg bg-blood px-4 py-[0.45rem] text-[clamp(0.65rem,0.9vw,0.75rem)] font-semibold text-charcoal shadow transition-transform hover:scale-105 hover:bg-blood"
           >
             Get Started →
           </CTAButton>

--- a/src/components/homepage/IndustryTemplates.tsx
+++ b/src/components/homepage/IndustryTemplates.tsx
@@ -13,7 +13,7 @@ export default function IndustryTemplatesSection() {
   return (
     <section
       id="templates"
-      className="bg-olive text-charcoal w-full scroll-mt-[120px] overflow-x-hidden py-[clamp(5rem,10vw,8rem)]"
+      className="w-full scroll-mt-[120px] overflow-x-hidden bg-olive text-charcoal py-[clamp(5rem,10vw,8rem)]"
     >
       <div className="container mx-auto max-w-4xl px-4 sm:px-6 lg:px-8">
         <div className="mb-12 text-center">
@@ -25,9 +25,11 @@ export default function IndustryTemplatesSection() {
           </p>
         </div>
 
-        <div className="group mx-auto flex max-w-6xl flex-col gap-8 md:flex-row md:items-start">
+        <div
+          className="group mx-auto flex max-w-4xl flex-col gap-6 md:flex-row md:items-start"
+        >
           <div
-            className="relative mb-4 aspect-[2/3] h-[80vh] max-h-[80vh] overflow-hidden rounded-lg md:mr-6 md:mb-0"
+            className="relative mb-4 aspect-[2/3] h-[80vh] max-h-[80vh] overflow-hidden rounded-lg md:mb-0 md:mr-6"
             style={{ perspective: '1000px' }}
           >
             <Image
@@ -35,11 +37,13 @@ export default function IndustryTemplatesSection() {
               alt={`Screenshot of ${authority.title}`}
               width={640}
               height={960}
-              className="h-full w-full origin-left rounded-lg object-cover transition-transform duration-500 group-hover:[transform:rotateY(12deg)]"
+              className="h-full w-full rounded-lg object-cover transition-transform duration-500 origin-left group-hover:[transform:rotateY(12deg)]"
               priority
             />
           </div>
-          <div className="flex flex-grow origin-left transform-gpu flex-col transition-all duration-500 group-hover:[transform:translateX(1.5rem)_rotateY(-6deg)] md:w-1/2">
+          <div
+            className="flex flex-grow flex-col md:w-1/2 origin-left transform-gpu transition-all duration-500 group-hover:[transform:translateX(1.5rem)_rotateY(-6deg)]"
+          >
             <h4 className="text-charcoal mb-1 truncate text-[clamp(1rem,1.8vw,1.25rem)] font-semibold">
               {authority.title}
             </h4>

--- a/src/components/homepage/PricingSection.tsx
+++ b/src/components/homepage/PricingSection.tsx
@@ -1,25 +1,27 @@
-'use client';
+'use client'
 
-import { pricing } from '@/content/homepage/pricing';
-import QuoteModal from './QuoteModal';
-import { motion } from 'framer-motion';
-import Link from 'next/link';
+import { pricing } from '@/content/homepage/pricing'
+import QuoteModal from './QuoteModal'
+import { motion } from 'framer-motion'
+import Link from 'next/link'
 
 export default function PricingSection() {
   return (
     <section
       id="pricing"
-      className="bg-antique text-charcoal w-full border-t py-[clamp(5rem,10vw,8rem)]"
+      className="w-full border-t bg-antique text-charcoal py-[clamp(5rem,10vw,8rem)]"
     >
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <div className="mx-auto max-w-4xl space-y-4 text-center">
           <h2 className="text-[clamp(1.75rem,3.5vw,2.5rem)] font-bold tracking-tight">
             Our Packages
           </h2>
-          <p className="text-silver text-[clamp(0.9rem,1.6vw,1.125rem)]">{pricing.headline}</p>
+          <p className="text-[clamp(0.9rem,1.6vw,1.125rem)] text-silver">
+            {pricing.headline}
+          </p>
         </div>
 
-        <div className="mx-auto mt-12 grid gap-8 md:grid-cols-2 lg:grid-cols-4">
+        <div className="mx-auto mt-12 grid gap-6 md:grid-cols-2 lg:grid-cols-4">
           {pricing.tiers.map((tier, index) => (
             <motion.div
               key={tier.title}
@@ -27,31 +29,38 @@ export default function PricingSection() {
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               transition={{ duration: 0.6, delay: index * 0.1 }}
-              className={`border-silver bg-olive relative flex flex-col overflow-hidden rounded-2xl border p-6 ${tier.highlight ? 'ring-blood ring-2' : ''}`}
+              className={`relative flex flex-col overflow-hidden rounded-2xl border border-silver bg-olive p-6 ${tier.highlight ? 'ring-2 ring-blood' : ''}`}
             >
               {tier.highlight && (
                 <motion.div
                   animate={{ opacity: [0.4, 0.8, 0.4] }}
                   transition={{ duration: 6, repeat: Infinity }}
-                  className="from-blood/25 pointer-events-none absolute inset-0 -z-10 rounded-2xl bg-[radial-gradient(circle,var(--tw-gradient-stops))] to-transparent"
+                  className="pointer-events-none absolute inset-0 -z-10 rounded-2xl bg-[radial-gradient(circle,var(--tw-gradient-stops))] from-blood/25 to-transparent"
                 />
               )}
               <div className="flex items-baseline justify-between">
-                <h3 className="text-[clamp(1rem,1.8vw,1.25rem)] font-semibold">{tier.title}</h3>
-                <span className="text-charcoal text-[clamp(1rem,1.8vw,1.25rem)] font-bold">
+                <h3 className="text-[clamp(1rem,1.8vw,1.25rem)] font-semibold">
+                  {tier.title}
+                </h3>
+                <span className="text-[clamp(1rem,1.8vw,1.25rem)] font-bold text-charcoal">
                   {tier.price}
                 </span>
               </div>
-              <p className="text-charcoal mt-1 text-[clamp(0.8rem,1.2vw,0.9rem)] italic">
+              <p className="mt-1 text-[clamp(0.8rem,1.2vw,0.9rem)] italic text-charcoal">
                 {tier.microcopy}
               </p>
-              <p className="text-charcoal mt-2 text-[clamp(0.8rem,1.2vw,0.9rem)]">
+              <p className="mt-2 text-[clamp(0.8rem,1.2vw,0.9rem)] text-charcoal">
                 {tier.description}
               </p>
-              <ul className="text-charcoal mt-4 flex-1 space-y-1 text-[clamp(0.8rem,1.2vw,0.9rem)]">
+              <ul className="mt-4 flex-1 space-y-1 text-[clamp(0.8rem,1.2vw,0.9rem)] text-charcoal">
                 {tier.features.map((feature, i) => (
-                  <li key={i} className={i === 0 ? 'text-silver font-semibold' : ''}>
-                    <span className="text-blood mr-1">{i === 0 ? '✅' : '✓'}</span>
+                  <li
+                    key={i}
+                    className={i === 0 ? 'font-semibold text-silver' : ''}
+                  >
+                    <span className="mr-1 text-blood">
+                      {i === 0 ? '✅' : '✓'}
+                    </span>
                     {feature}
                   </li>
                 ))}
@@ -60,7 +69,7 @@ export default function PricingSection() {
                 <Link
                   href="/contact"
                   data-event="cta-pricing"
-                  className="border-silver bg-antique text-charcoal hover:bg-silver block w-full rounded-full border px-[clamp(1rem,2.5vw,1.25rem)] py-[clamp(0.6rem,1.2vw,0.75rem)] text-center text-[clamp(0.8rem,1vw,0.9rem)] font-medium shadow-sm transition hover:scale-105"
+                  className="block w-full rounded-full border border-silver bg-antique px-[clamp(1rem,2.5vw,1.25rem)] py-[clamp(0.6rem,1.2vw,0.75rem)] text-center text-[clamp(0.8rem,1vw,0.9rem)] font-medium text-charcoal shadow-sm transition hover:scale-105 hover:bg-silver"
                 >
                   {tier.cta}
                 </Link>
@@ -77,5 +86,5 @@ export default function PricingSection() {
         </div>
       </div>
     </section>
-  );
+  )
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -6,14 +6,6 @@
 
 /* Global CSS Variables and Base Styles */
 :root {
-  --spacing: 0.25rem;
-  --container-md: 28rem;
-  --container-xl: 36rem;
-  --container-2xl: 42rem;
-  --container-3xl: 48rem;
-  --container-4xl: 56rem;
-  --container-6xl: 72rem;
-  --container-7xl: 80rem;
   --header-height: 4rem;
   --section-padding: 6rem;
   --max-content-width: 1280px;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -6,7 +6,7 @@
 
 /* Global CSS Variables and Base Styles */
 :root {
-  --header-height: 4rem;
+  --header-height: 3.75rem;
   --section-padding: 6rem;
   --max-content-width: 1280px;
 


### PR DESCRIPTION
## Summary
- revert global layout variables
- restore header, template, and pricing spacing

## Testing
- `pnpm lint`
- `pnpm build:css`


------
https://chatgpt.com/codex/tasks/task_e_686bdc64b39c8328b692dfee2946dc2f