### PR TITLE
Fix header color toggle

### DIFF
--- a/src/components/global/Header.tsx
+++ b/src/components/global/Header.tsx
@@ -25,7 +25,7 @@ export default function StickyHeader({ light = false }: HeaderProps) {
     return () => window.removeEventListener('scroll', onScroll);
   }, []);
 
-  const textColor = light ? 'text-charcoal' : 'text-charcoal';
+  const textColor = scrolled || light ? 'text-charcoal' : 'text-offwhite';
 
   return (
     <motion.header

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -80,7 +80,12 @@ h6 {
 }
 
 a {
+  color: inherit;
   text-decoration: none;
+}
+
+a:visited {
+  color: inherit;
 }
 
 img {


### PR DESCRIPTION
## Summary
- adjust sticky header color logic to show dark text when scrolled or on light backgrounds

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6870427972fc83289ce6eff78700c6ff