### PR TITLE
Apply new psychological color palette

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -164,6 +164,9 @@
 .z-30 {
   z-index: 30;
 }
+.z-40 {
+  z-index: 40;
+}
 .z-50 {
   z-index: 50;
 }
@@ -263,6 +266,9 @@
 .ml-\[calc\(50vw-1rem\)\] {
   margin-left: calc(50vw - 1rem);
 }
+.ml-auto {
+  margin-left: auto;
+}
 .box-border {
   box-sizing: border-box;
 }
@@ -346,6 +352,9 @@
 }
 .max-h-\[80vh\] {
   max-height: 80vh;
+}
+.min-h-\[100svh\] {
+  min-height: 100svh;
 }
 .min-h-screen {
   min-height: 100vh;
@@ -500,6 +509,9 @@
 }
 .snap-start {
   scroll-snap-align: start;
+}
+.scroll-mt-\[80px\] {
+  scroll-margin-top: 80px;
 }
 .scroll-mt-\[120px\] {
   scroll-margin-top: 120px;
@@ -685,17 +697,8 @@
   --tw-border-style: none;
   border-style: none;
 }
-.border-\[\#b30000\] {
-  border-color: #b30000;
-}
 .border-t-transparent {
   border-top-color: transparent;
-}
-.bg-neutral-50\/80 {
-  background-color: color-mix(in srgb, oklch(98.5% 0 0) 80%, transparent);
-  @supports (color: color-mix(in lab, red, red)) {
-    background-color: color-mix(in oklab, var(--color-neutral-50) 80%, transparent);
-  }
 }
 .bg-transparent {
   background-color: transparent;
@@ -725,10 +728,6 @@
 .bg-\[radial-gradient\(circle_at_center\,var\(--tw-gradient-stops\)\)\] {
   background-image: radial-gradient(circle at center,var(--tw-gradient-stops));
 }
-.from-\[\#b30000\] {
-  --tw-gradient-from: #b30000;
-  --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
-}
 .from-black\/20 {
   --tw-gradient-from: color-mix(in srgb, #000 20%, transparent);
   @supports (color: color-mix(in lab, red, red)) {
@@ -756,10 +755,6 @@
   }
   --tw-gradient-via-stops: var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-via) var(--tw-gradient-via-position), var(--tw-gradient-to) var(--tw-gradient-to-position);
   --tw-gradient-stops: var(--tw-gradient-via-stops);
-}
-.to-orange-500 {
-  --tw-gradient-to: var(--color-orange-500);
-  --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
 }
 .to-transparent {
   --tw-gradient-to: transparent;
@@ -1103,24 +1098,6 @@
   --tw-tracking: var(--tracking-widest);
   letter-spacing: var(--tracking-widest);
 }
-.text-\[\#333\] {
-  color: #333;
-}
-.text-\[\#666\] {
-  color: #666;
-}
-.text-\[\#b30000\] {
-  color: #b30000;
-}
-.text-black\/50 {
-  color: color-mix(in srgb, #000 50%, transparent);
-  @supports (color: color-mix(in lab, red, red)) {
-    color: color-mix(in oklab, var(--color-black) 50%, transparent);
-  }
-}
-.text-neutral-500 {
-  color: var(--color-neutral-500);
-}
 .text-transparent {
   color: transparent;
 }
@@ -1174,8 +1151,8 @@
   --tw-shadow: 0 25px 50px -12px var(--tw-shadow-color, rgb(0 0 0 / 0.25));
   box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
 }
-.shadow-\[0_0_20px_rgba\(255\,0\,0\,0\.2\)\] {
-  --tw-shadow: 0 0 20px var(--tw-shadow-color, rgba(255,0,0,0.2));
+.shadow-\[0_0_20px_rgba\(179\,0\,0\,0\.2\)\] {
+  --tw-shadow: 0 0 20px var(--tw-shadow-color, rgba(179,0,0,0.2));
   box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
 }
 .shadow-inner {
@@ -1209,12 +1186,6 @@
 .ring-2 {
   --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
   box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
-}
-.ring-red-500\/20 {
-  --tw-ring-color: color-mix(in srgb, oklch(63.7% 0.237 25.331) 20%, transparent);
-  @supports (color: color-mix(in lab, red, red)) {
-    --tw-ring-color: color-mix(in oklab, var(--color-red-500) 20%, transparent);
-  }
 }
 .ring-transparent {
   --tw-ring-color: transparent;
@@ -1288,9 +1259,6 @@
 .ease-in-out {
   --tw-ease: var(--ease-in-out);
   transition-timing-function: var(--ease-in-out);
-}
-.ring-inset {
-  --tw-ring-inset: inset;
 }
 .group-hover\:translate-x-1 {
   &:is(:where(.group):hover *) {
@@ -1441,34 +1409,6 @@
     }
   }
 }
-.hover\:bg-\[\#b30000\] {
-  &:hover {
-    @media (hover: hover) {
-      background-color: #b30000;
-    }
-  }
-}
-.hover\:text-\[\#222\] {
-  &:hover {
-    @media (hover: hover) {
-      color: #222;
-    }
-  }
-}
-.hover\:text-\[\#b30000\] {
-  &:hover {
-    @media (hover: hover) {
-      color: #b30000;
-    }
-  }
-}
-.hover\:text-white {
-  &:hover {
-    @media (hover: hover) {
-      color: var(--color-white);
-    }
-  }
-}
 .hover\:underline {
   &:hover {
     @media (hover: hover) {
@@ -1527,11 +1467,6 @@
   &:focus-visible {
     outline-style: var(--tw-outline-style);
     outline-width: 2px;
-  }
-}
-.focus-visible\:outline-red-500 {
-  &:focus-visible {
-    outline-color: var(--color-red-500);
   }
 }
 .focus-visible\:outline-none {
@@ -1733,32 +1668,6 @@
     padding-inline: calc(var(--spacing) * 20);
   }
 }
-.dark\:bg-neutral-900\/80 {
-  @media (prefers-color-scheme: dark) {
-    background-color: color-mix(in srgb, oklch(20.5% 0 0) 80%, transparent);
-    @supports (color: color-mix(in lab, red, red)) {
-      background-color: color-mix(in oklab, var(--color-neutral-900) 80%, transparent);
-    }
-  }
-}
-.dark\:text-neutral-300 {
-  @media (prefers-color-scheme: dark) {
-    color: var(--color-neutral-300);
-  }
-}
-.dark\:text-neutral-400 {
-  @media (prefers-color-scheme: dark) {
-    color: var(--color-neutral-400);
-  }
-}
-.dark\:text-white\/50 {
-  @media (prefers-color-scheme: dark) {
-    color: color-mix(in srgb, #fff 50%, transparent);
-    @supports (color: color-mix(in lab, red, red)) {
-      color: color-mix(in oklab, var(--color-white) 50%, transparent);
-    }
-  }
-}
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap');
 :root {
   --spacing: 0.25rem;
@@ -1790,10 +1699,8 @@
   --color-silver-rgb: 210 210 210;
   --color-charcoal: #2f2f2f;
   --color-charcoal-rgb: 47 47 47;
-  --color-soft-dark: #333333;
-  --color-soft-dark-rgb: 51 51 51;
-  --color-blood: #cc0000;
-  --color-blood-rgb: 204 0 0;
+  --color-blood: #b30000;
+  --color-blood-rgb: 179 0 0;
   --color-crimson: #7a0000;
   --color-crimson-rgb: 122 0 0;
   --color-bg-primary: var(--color-antique);
@@ -1816,6 +1723,27 @@ body {
   margin: 0;
   padding: 0;
   overflow-x: hidden;
+  padding-bottom: env(safe-area-inset-bottom);
+}
+p {
+  overflow-wrap: break-word;
+  word-break: break-word;
+  -webkit-hyphens: auto;
+          hyphens: auto;
+}
+.skip-link {
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform: translateY(-100%);
+  padding: 0.75rem 1rem;
+  background: rgb(var(--color-blood-rgb));
+  color: #fff;
+  z-index: 100;
+  transition: transform 0.3s ease;
+}
+.skip-link:focus {
+  transform: translateY(0);
 }
 h1,
 h2,

--- a/src/components/CTAButton.tsx
+++ b/src/components/CTAButton.tsx
@@ -8,7 +8,7 @@ interface CTAButtonProps {
   className?: string;
 }
 
-export default function CTAButton({ href, children, event, className = 'inline-flex items-center justify-center rounded-[6px] bg-blood px-8 py-5 text-sm font-bold text-charcoal shadow-md transition hover:scale-105 hover:bg-blood cta-glow ripple-hover' }: CTAButtonProps) {
+export default function CTAButton({ href, children, event, className = 'inline-flex items-center justify-center rounded-[6px] bg-blood px-8 py-5 text-sm font-bold text-silver shadow-md transition hover:scale-105 hover:bg-crimson cta-glow ripple-hover' }: CTAButtonProps) {
   return (
     <Link href={href} data-event={event} className={className}>
       {children}

--- a/src/components/global/Header.tsx
+++ b/src/components/global/Header.tsx
@@ -78,7 +78,7 @@ export default function StickyHeader({ light = false }: HeaderProps) {
         transition={{ duration: 0.6 }}
         className={`w-full transition-all duration-500 ease-in-out ${
           scrolled
-            ? 'bg-neutral-50/80 dark:bg-neutral-900/80 shadow-md backdrop-blur-md rounded-b-lg'
+            ? 'bg-sepia/80 shadow-md backdrop-blur-md rounded-b-lg'
             : 'bg-transparent backdrop-blur-0'
         } ${textColor}`}
       >
@@ -96,7 +96,7 @@ export default function StickyHeader({ light = false }: HeaderProps) {
               tabIndex={0}
               onClick={scrollToTop}
               onKeyDown={handleKey}
-              className="logo-glow logo-hover flex text-[clamp(0.9rem,1.4vw,1.25rem)] font-bold tracking-[0.5px] transition-transform transition-colors text-[#666] hover:text-[#222] hover:scale-105"
+              className="logo-glow logo-hover flex text-[clamp(0.9rem,1.4vw,1.25rem)] font-bold tracking-[0.5px] transition-transform transition-colors text-charcoal hover:text-olive hover:scale-105"
             >
               {"NPR MEDIA".split("").map((ch, i) =>
                 ch === " " ? (
@@ -122,44 +122,44 @@ export default function StickyHeader({ light = false }: HeaderProps) {
           <Link
             href="/pricing" aria-label="Navigate to Pricing section"
             aria-current={activeSection === 'pricing' ? 'true' : undefined}
-            className="group font-grotesk font-medium text-[clamp(0.75rem,1vw,0.875rem)] relative after:absolute after:left-0 after:-bottom-0.5 after:h-px after:w-full after:origin-left after:scale-x-0 after:bg-current after:transition-transform after:duration-300 group-hover:after:scale-x-100 hover:text-[#b30000] focus-visible:outline outline-offset-2"
+            className="group font-grotesk font-medium text-[clamp(0.75rem,1vw,0.875rem)] relative after:absolute after:left-0 after:-bottom-0.5 after:h-px after:w-full after:origin-left after:scale-x-0 after:bg-current after:transition-transform after:duration-300 group-hover:after:scale-x-100 hover:text-olive focus-visible:outline outline-offset-2"
           >
             Pricing
           </Link>
           <Link
             href="/about" aria-label="Navigate to About section"
             aria-current={activeSection === 'about' ? 'true' : undefined}
-            className="group font-grotesk font-medium text-[clamp(0.75rem,1vw,0.875rem)] relative after:absolute after:left-0 after:-bottom-0.5 after:h-px after:w-full after:origin-left after:scale-x-0 after:bg-current after:transition-transform after:duration-300 group-hover:after:scale-x-100 hover:text-[#b30000] focus-visible:outline outline-offset-2"
+            className="group font-grotesk font-medium text-[clamp(0.75rem,1vw,0.875rem)] relative after:absolute after:left-0 after:-bottom-0.5 after:h-px after:w-full after:origin-left after:scale-x-0 after:bg-current after:transition-transform after:duration-300 group-hover:after:scale-x-100 hover:text-olive focus-visible:outline outline-offset-2"
           >
             About
           </Link>
           <Link
             href={Routes.contact} aria-label="Navigate to Contact section"
             aria-current={activeSection === 'contact' ? 'true' : undefined}
-            className="group font-grotesk font-medium text-[clamp(0.75rem,1vw,0.875rem)] relative after:absolute after:left-0 after:-bottom-0.5 after:h-px after:w-full after:origin-left after:scale-x-0 after:bg-current after:transition-transform after:duration-300 group-hover:after:scale-x-100 hover:text-[#b30000] focus-visible:outline outline-offset-2"
+            className="group font-grotesk font-medium text-[clamp(0.75rem,1vw,0.875rem)] relative after:absolute after:left-0 after:-bottom-0.5 after:h-px after:w-full after:origin-left after:scale-x-0 after:bg-current after:transition-transform after:duration-300 group-hover:after:scale-x-100 hover:text-olive focus-visible:outline outline-offset-2"
           >
             Contact
           </Link>
           <Link
             href="/blog" aria-label="Navigate to Blog section"
             aria-current={activeSection === 'blog' ? 'true' : undefined}
-            className="group font-grotesk font-medium text-[clamp(0.75rem,1vw,0.875rem)] relative after:absolute after:left-0 after:-bottom-0.5 after:h-px after:w-full after:origin-left after:scale-x-0 after:bg-current after:transition-transform after:duration-300 group-hover:after:scale-x-100 hover:text-[#b30000] focus-visible:outline outline-offset-2"
+            className="group font-grotesk font-medium text-[clamp(0.75rem,1vw,0.875rem)] relative after:absolute after:left-0 after:-bottom-0.5 after:h-px after:w-full after:origin-left after:scale-x-0 after:bg-current after:transition-transform after:duration-300 group-hover:after:scale-x-100 hover:text-olive focus-visible:outline outline-offset-2"
           >
             Blog
           </Link>
           <Link
             href="/why-npr" aria-label="Navigate to Why NPR section"
             aria-current={activeSection === 'why-npr' ? 'true' : undefined}
-            className="group font-grotesk font-medium text-[clamp(0.75rem,1vw,0.875rem)] relative after:absolute after:left-0 after:-bottom-0.5 after:h-px after:w-full after:origin-left after:scale-x-0 after:bg-current after:transition-transform after:duration-300 group-hover:after:scale-x-100 hover:text-[#b30000] focus-visible:outline outline-offset-2"
+            className="group font-grotesk font-medium text-[clamp(0.75rem,1vw,0.875rem)] relative after:absolute after:left-0 after:-bottom-0.5 after:h-px after:w-full after:origin-left after:scale-x-0 after:bg-current after:transition-transform after:duration-300 group-hover:after:scale-x-100 hover:text-olive focus-visible:outline outline-offset-2"
           >
             Why NPR
           </Link>
-          <CTAButton
-            href="/webdev-landing"
-            event="cta-navbar"
-            aria-label="Start your project"
-            className="group relative ml-4 inline-flex items-center gap-2 rounded-full border border-[#b30000] bg-transparent px-[clamp(1rem,2.5vw,1.5rem)] py-[clamp(0.5rem,1.2vh,0.75rem)] text-[clamp(0.875rem,1.2vw,1rem)] font-bold text-[#b30000] shadow-none transition-all duration-300 hover:scale-105 hover:bg-[#b30000] hover:text-white focus-visible:outline focus-visible:outline-red-500 cta-glow ripple-hover"
-          >
+            <CTAButton
+              href="/webdev-landing"
+              event="cta-navbar"
+              aria-label="Start your project"
+              className="group relative ml-4 inline-flex items-center gap-2 rounded-full border border-blood bg-blood px-[clamp(1rem,2.5vw,1.5rem)] py-[clamp(0.5rem,1.2vh,0.75rem)] text-[clamp(0.875rem,1.2vw,1rem)] font-bold text-silver shadow-none transition-all duration-300 hover:scale-105 hover:bg-crimson focus-visible:outline focus-visible:outline-crimson cta-glow ripple-hover"
+            >
             <span>Get Started</span>
             <span className="transition-transform group-hover:translate-x-1">→</span>
           </CTAButton>
@@ -176,12 +176,12 @@ export default function StickyHeader({ light = false }: HeaderProps) {
             <Link onClick={() => setMenuOpen(false)} href={Routes.contact}>Contact</Link>
             <Link onClick={() => setMenuOpen(false)} href="/blog">Blog</Link>
             <Link onClick={() => setMenuOpen(false)} href="/why-npr">Why NPR</Link>
-            <CTAButton
-              href="/webdev-landing"
-              event="cta-navbar"
-              aria-label="Start your project"
-              className="mt-4 inline-flex items-center gap-2 rounded-full border border-[#b30000] bg-transparent px-6 py-3 text-sm font-bold text-[#b30000] shadow-none hover:bg-[#b30000] hover:text-white"
-            >
+              <CTAButton
+                href="/webdev-landing"
+                event="cta-navbar"
+                aria-label="Start your project"
+                className="mt-4 inline-flex items-center gap-2 rounded-full border border-blood bg-blood px-6 py-3 text-sm font-bold text-silver shadow-none hover:bg-crimson"
+              >
               <span>Get Started</span>
               <span className="transition-transform group-hover:translate-x-1">→</span>
             </CTAButton>

--- a/src/components/homepage/Hero.tsx
+++ b/src/components/homepage/Hero.tsx
@@ -188,7 +188,7 @@ const HeroSection: React.FC<HeroProps> = ({ headline, subheadline, ctaText, ctaL
             data-scroll
             variants={textVariants}
             custom={1}
-            className="glow-blood mb-6 w-full text-transparent bg-gradient-to-r from-[#b30000] to-orange-500 bg-clip-text text-[clamp(2.5rem,6vw,4.5rem)] leading-[1.1] font-grotesk font-bold tracking-tight"
+            className="glow-blood mb-6 w-full text-transparent bg-gradient-to-r from-blood to-crimson bg-clip-text text-[clamp(2.5rem,6vw,4.5rem)] leading-[1.1] font-grotesk font-bold tracking-tight"
           >
             {headlineLines.map((line, li) => (
               <span key={li} className="block overflow-hidden">
@@ -210,7 +210,7 @@ const HeroSection: React.FC<HeroProps> = ({ headline, subheadline, ctaText, ctaL
               id="hero-subheadline"
               aria-describedby="hero-headline"
               variants={subheadlineVariants}
-              className="font-grotesk font-medium text-[#333] dark:text-neutral-300 opacity-90 md:opacity-100 mt-6 sm:mt-8 lg:mt-10 mb-7 mx-auto max-w-[60ch] text-center text-[clamp(1rem,1.5vw,1.25rem)] leading-[1.6]"
+              className="font-grotesk font-medium text-charcoal opacity-90 md:opacity-100 mt-6 sm:mt-8 lg:mt-10 mb-7 mx-auto max-w-[60ch] text-center text-[clamp(1rem,1.5vw,1.25rem)] leading-[1.6]"
             >
               {subheadline}
             </motion.p>
@@ -225,7 +225,7 @@ const HeroSection: React.FC<HeroProps> = ({ headline, subheadline, ctaText, ctaL
                 ref={ctaRef}
                 aria-label="Start your project with NPR Media"
                 onClick={() => router.push(ctaLink)}
-                className="cta-glow ripple-hover inline-flex items-center justify-center rounded-full border border-[#b30000] ring-1 ring-inset ring-red-500/20 px-[clamp(1.875rem,3.75vw,2.5rem)] py-[clamp(0.9rem,1.5vw,1.25rem)] text-[clamp(0.875rem,1vw,1rem)] font-bold uppercase tracking-wide text-charcoal shadow-[0_0_20px_rgba(255,0,0,0.2)] transition-transform duration-300 hover:scale-105 hover:bg-[#b30000] hover:text-white focus-visible:outline focus-visible:outline-red-500"
+                className="cta-glow ripple-hover inline-flex items-center justify-center rounded-full border border-blood bg-blood px-[clamp(1.875rem,3.75vw,2.5rem)] py-[clamp(0.9rem,1.5vw,1.25rem)] text-[clamp(0.875rem,1vw,1rem)] font-bold uppercase tracking-wide text-silver shadow-[0_0_20px_rgba(179,0,0,0.2)] transition-transform duration-300 hover:scale-105 hover:bg-crimson focus-visible:outline focus-visible:outline-crimson"
               >
                 <span>{ctaText}</span>
                 <motion.span
@@ -246,7 +246,7 @@ const HeroSection: React.FC<HeroProps> = ({ headline, subheadline, ctaText, ctaL
             role="note"
             aria-label="SOC2 certified and founder-backed"
             variants={badgeVariants}
-            className="mt-6 sm:mt-8 text-center sm:text-left flex items-center justify-center sm:justify-start text-neutral-500 dark:text-neutral-400 text-[clamp(0.75rem,0.9vw,0.875rem)] font-medium uppercase tracking-wider font-smallcaps"
+            className="mt-6 sm:mt-8 text-center sm:text-left flex items-center justify-center sm:justify-start text-olive text-[clamp(0.75rem,0.9vw,0.875rem)] font-medium uppercase tracking-wider font-smallcaps"
           >
             <ShieldCheck className="mr-2 h-4 w-4 flex-shrink-0" />
             <span>SOC2 Certified • GDPR Ready • Trusted by 10,000+ users</span>
@@ -271,7 +271,7 @@ const HeroSection: React.FC<HeroProps> = ({ headline, subheadline, ctaText, ctaL
               initial={{ opacity: 0, y: -20 }}
               animate={{ opacity: 1, y: 0, transition: { delay: 1, duration: 1, ease: 'easeOut' } }}
               style={{ opacity: letter === 'R' ? rOpacity : 1 }}
-              className="block font-grotesk font-extrabold uppercase leading-none text-black/50 dark:text-white/50 text-[33vh]"
+              className="block font-grotesk font-extrabold uppercase leading-none text-charcoal/50 text-[33vh]"
             >
               {letter}
             </motion.span>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -38,10 +38,8 @@
   --color-silver-rgb: 210 210 210;
   --color-charcoal: #2f2f2f;
   --color-charcoal-rgb: 47 47 47;
-  --color-soft-dark: #333333;
-  --color-soft-dark-rgb: 51 51 51;
-  --color-blood: #cc0000;
-  --color-blood-rgb: 204 0 0;
+  --color-blood: #b30000;
+  --color-blood-rgb: 179 0 0;
   --color-crimson: #7a0000;
   --color-crimson-rgb: 122 0 0;
 


### PR DESCRIPTION
## Summary
- update CSS variables to match new 8‑color palette
- purge neutral/dark shades from navigation and hero components
- restyle CTAs to use blood and crimson states
- compile updated Tailwind styles

## Testing
- `pnpm lint`
- `pnpm build:css`


------
https://chatgpt.com/codex/tasks/task_e_68758502ea5083289a75c5c4a23195f9