### PR TITLE
Update border colors to follow style guide

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1859,11 +1859,11 @@ img {
   .ring-blood\/50 {
     box-shadow: 0 0 0 2px rgb(var(--color-blood-rgb) / 0.5);
   }
-  .ring-silver\/10 {
-    box-shadow: 0 0 0 1px rgb(var(--color-silver-rgb) / 0.1);
+  .ring-olive\/10 {
+    box-shadow: 0 0 0 1px rgb(var(--color-olive-rgb) / 0.1);
   }
-  .ring-silver\/20 {
-    box-shadow: 0 0 0 1px rgb(var(--color-silver-rgb) / 0.2);
+  .ring-olive\/20 {
+    box-shadow: 0 0 0 1px rgb(var(--color-olive-rgb) / 0.2);
   }
   .shadow-silver\/20 {
     box-shadow: 0 1px 3px 0 rgb(var(--color-silver-rgb) / 0.2);

--- a/public/styles.css
+++ b/public/styles.css
@@ -1853,6 +1853,9 @@ img {
   .bg-silver\/30 {
     background-color: rgb(var(--color-silver-rgb) / 0.3);
   }
+  .ring-blood {
+    box-shadow: 0 0 0 2px rgb(var(--color-blood-rgb));
+  }
   .ring-blood\/40 {
     box-shadow: 0 0 0 2px rgb(var(--color-blood-rgb) / 0.4);
   }
@@ -1864,6 +1867,9 @@ img {
   }
   .ring-olive\/20 {
     box-shadow: 0 0 0 1px rgb(var(--color-olive-rgb) / 0.2);
+  }
+  .ring-olive {
+    box-shadow: 0 0 0 1px rgb(var(--color-olive-rgb));
   }
   .shadow-silver\/20 {
     box-shadow: 0 1px 3px 0 rgb(var(--color-silver-rgb) / 0.2);

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -65,15 +65,15 @@ export default function ContactPage() {
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.6, delay: 0.2 }}
           >
-            <div className="flex flex-col items-center rounded-xl bg-olive/80 p-4 shadow-md ring-1 ring-silver/20 backdrop-blur-md">
+            <div className="flex flex-col items-center rounded-xl bg-olive/80 p-4 shadow-md ring-1 ring-olive/20 backdrop-blur-md">
               <Phone className="mb-2 h-5 w-5 text-blood" />
               <p className="text-sm">+1 (555) 123-4567</p>
             </div>
-            <div className="flex flex-col items-center rounded-xl bg-olive/80 p-4 shadow-md ring-1 ring-silver/20 backdrop-blur-md">
+            <div className="flex flex-col items-center rounded-xl bg-olive/80 p-4 shadow-md ring-1 ring-olive/20 backdrop-blur-md">
               <Mail className="mb-2 h-5 w-5 text-blood" />
               <p className="text-sm">contact@npr-media.com</p>
             </div>
-            <div className="flex flex-col items-center rounded-xl bg-olive/80 p-4 shadow-md ring-1 ring-silver/20 backdrop-blur-md">
+            <div className="flex flex-col items-center rounded-xl bg-olive/80 p-4 shadow-md ring-1 ring-olive/20 backdrop-blur-md">
               <Calendar className="mb-2 h-5 w-5 text-blood" />
               <a
                 href="https://calendly.com"

--- a/src/app/why-npr/page.tsx
+++ b/src/app/why-npr/page.tsx
@@ -183,7 +183,7 @@ export default function WhyNprPage() {
               <a
                 href="/webdev-landing"
                 data-event="cta-social-proof"
-                className="inline-block rounded-full bg-gradient-to-r from-blood to-blood px-6 py-3 text-sm font-semibold text-silver shadow-md ring-1 ring-silver/10 transition hover:scale-105"
+                className="inline-block rounded-full bg-gradient-to-r from-blood to-blood px-6 py-3 text-sm font-semibold text-silver shadow-md ring-1 ring-olive/10 transition hover:scale-105"
               >
                 Don’t get AI’d. Get outcomes.
               </a>
@@ -316,7 +316,7 @@ export default function WhyNprPage() {
               <a
                 href="/webdev-landing"
                 data-event="cta-social-proof"
-                className="inline-block rounded-full bg-gradient-to-r from-blood to-blood px-6 py-3 text-sm font-semibold text-silver shadow-md ring-1 ring-silver/20 transition hover:scale-105"
+                className="inline-block rounded-full bg-gradient-to-r from-blood to-blood px-6 py-3 text-sm font-semibold text-silver shadow-md ring-1 ring-olive/20 transition hover:scale-105"
               >
                 This time, don’t settle.
               </a>

--- a/src/app/why-npr/page.tsx
+++ b/src/app/why-npr/page.tsx
@@ -173,7 +173,7 @@ export default function WhyNprPage() {
                   whileInView={{ opacity: 1, y: 0 }}
                   viewport={{ once: true }}
                   transition={{ duration: 0.6 }}
-                  className="rounded border border-silver/30 bg-silver/10 p-3 text-silver shadow-inner"
+                  className="rounded border border-olive/30 bg-silver/10 p-3 text-silver shadow-inner"
                 >
                   Bold hook → stat → CTA
                 </motion.div>

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -260,7 +260,7 @@ export default function ContactForm({ onSuccess }: ContactFormProps) {
         className="relative flex w-full items-center justify-center gap-2 rounded-xl bg-blood py-3 font-semibold text-charcoal shadow-md ring-2 ring-blood/50 transition-transform hover:shadow-lg disabled:opacity-60"
       >
         {loading ? (
-          <span className="h-5 w-5 animate-spin rounded-full border-2 border-silver border-t-transparent" />
+          <span className="h-5 w-5 animate-spin rounded-full border-2 border-olive border-t-transparent" />
         ) : success ? (
           <Check className="h-5 w-5" />
         ) : (

--- a/src/components/global/Footer.tsx
+++ b/src/components/global/Footer.tsx
@@ -7,7 +7,7 @@ export default function Footer() {
   return (
     <footer
       id="footer"
-      className="border-t bg-antique px-[clamp(1rem,4vw,3rem)] py-[clamp(2.5rem,6vw,4rem)] text-center text-[clamp(0.75rem,1vw,0.875rem)] text-charcoal"
+      className="border-t border-umber bg-antique px-[clamp(1rem,4vw,3rem)] py-[clamp(2.5rem,6vw,4rem)] text-center text-[clamp(0.75rem,1vw,0.875rem)] text-charcoal"
     >
       <div className="mx-auto max-w-6xl space-y-8">
         <div className="space-y-4">

--- a/src/components/homepage/ContactSection.tsx
+++ b/src/components/homepage/ContactSection.tsx
@@ -11,7 +11,7 @@ export default function ContactSection() {
   return (
     <section
       id="contact"
-      className="relative border-t bg-antique text-charcoal scroll-mt-[80px] py-[clamp(5rem,10vw,8rem)] px-[clamp(1rem,4vw,3rem)] overflow-hidden"
+      className="relative border-t border-umber bg-antique text-charcoal scroll-mt-[80px] py-[clamp(5rem,10vw,8rem)] px-[clamp(1rem,4vw,3rem)] overflow-hidden"
     >
       <div className="absolute inset-0 -z-10 pointer-events-none">
         <div className="absolute left-1/2 top-0 h-64 w-64 -translate-x-1/2 rounded-full bg-blood opacity-20 blur-3xl" />

--- a/src/components/homepage/PricingSection.tsx
+++ b/src/components/homepage/PricingSection.tsx
@@ -9,7 +9,7 @@ export default function PricingSection() {
   return (
     <section
       id="pricing"
-      className="bg-antique text-charcoal w-full border-t scroll-mt-[80px] overflow-x-hidden py-[clamp(5rem,10vw,8rem)]"
+      className="bg-antique text-charcoal w-full border-t border-umber scroll-mt-[80px] overflow-x-hidden py-[clamp(5rem,10vw,8rem)]"
     >
       <div className="container mx-auto box-border px-4 sm:px-6 lg:px-8">
         <div className="mx-auto max-w-4xl space-y-4 text-center">
@@ -27,7 +27,7 @@ export default function PricingSection() {
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               transition={{ duration: 0.6, delay: index * 0.1 }}
-              className={`border-silver bg-olive relative flex flex-col overflow-hidden rounded-2xl border p-6 ${tier.highlight ? 'ring-blood ring-2' : ''}`}
+              className={`border-olive bg-olive relative flex flex-col overflow-hidden rounded-2xl border p-6 ${tier.highlight ? 'ring-blood ring-2' : ''}`}
             >
               {tier.highlight && (
                 <motion.div
@@ -60,7 +60,7 @@ export default function PricingSection() {
                 <Link
                   href="/contact"
                   data-event="cta-pricing"
-                  className="border-silver bg-antique text-charcoal hover:bg-silver block w-full box-border rounded-full border px-[clamp(1rem,2.5vw,1.25rem)] py-[clamp(0.6rem,1.2vw,0.75rem)] text-center text-[clamp(0.8rem,1vw,0.9rem)] font-medium shadow-sm transition hover:scale-105"
+                  className="border-olive bg-antique text-charcoal hover:bg-silver block w-full box-border rounded-full border px-[clamp(1rem,2.5vw,1.25rem)] py-[clamp(0.6rem,1.2vw,0.75rem)] text-center text-[clamp(0.8rem,1vw,0.9rem)] font-medium shadow-sm transition hover:scale-105"
                 >
                   {tier.cta}
                 </Link>

--- a/src/components/webdevLanding/Hero.tsx
+++ b/src/components/webdevLanding/Hero.tsx
@@ -38,7 +38,7 @@ export default function Hero({ headline, subheadline, cta }: HeroProps) {
           variants={textVariants}
           href="#cta"
           data-event="webdev-scroll-trigger"
-          className="mt-8 inline-block rounded-full bg-olive px-6 py-3 font-semibold text-charcoal shadow-lg ring-1 ring-silver/20 transition hover:scale-105 hover:bg-olive"
+          className="mt-8 inline-block rounded-full bg-olive px-6 py-3 font-semibold text-charcoal shadow-lg ring-1 ring-olive/20 transition hover:scale-105 hover:bg-olive"
         >
           {cta}
         </motion.a>

--- a/src/components/webdevLanding/MiniForm.tsx
+++ b/src/components/webdevLanding/MiniForm.tsx
@@ -32,7 +32,7 @@ export default function MiniForm() {
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true }}
       transition={{ duration: 0.6, delay: 0.2 }}
-      className="space-y-4 rounded-2xl bg-olive/20 p-6 shadow-xl ring-1 ring-silver/20 backdrop-blur"
+      className="space-y-4 rounded-2xl bg-olive/20 p-6 shadow-xl ring-1 ring-olive/20 backdrop-blur"
     >
       <div className="relative">
         <User className={iconBase} />

--- a/src/components/webdevLanding/MiniForm.tsx
+++ b/src/components/webdevLanding/MiniForm.tsx
@@ -67,7 +67,7 @@ export default function MiniForm() {
         disabled={loading || success}
         className="relative flex w-full items-center justify-center gap-2 rounded-xl bg-blood py-3 font-semibold text-charcoal shadow-md transition hover:bg-blood"
       >
-        {loading ? <span className="h-5 w-5 animate-spin rounded-full border-2 border-silver border-t-transparent" /> : success ? <Check className="h-5 w-5" /> : 'Start My Mockup'}
+        {loading ? <span className="h-5 w-5 animate-spin rounded-full border-2 border-olive border-t-transparent" /> : success ? <Check className="h-5 w-5" /> : 'Start My Mockup'}
       </motion.button>
       {success && <p className="pt-2 text-center text-sm text-silver">We’ll be in touch shortly.</p>}
     </motion.form>

--- a/src/components/webdevLanding/OfferStack.tsx
+++ b/src/components/webdevLanding/OfferStack.tsx
@@ -31,7 +31,7 @@ export default function OfferStack() {
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               transition={{ duration: 0.5, delay: i * 0.1 }}
-              className="rounded-2xl bg-olive/70 p-6 text-center shadow-xl ring-1 ring-silver/20 backdrop-blur-md hover:shadow-2xl"
+              className="rounded-2xl bg-olive/70 p-6 text-center shadow-xl ring-1 ring-olive/20 backdrop-blur-md hover:shadow-2xl"
             >
               <item.icon className="mx-auto mb-3 h-6 w-6 text-blood" />
               <h3 className="mb-1 font-semibold text-[clamp(1rem,1.6vw,1.25rem)]">{item.label}</h3>

--- a/src/components/webdevLanding/PainPoints.tsx
+++ b/src/components/webdevLanding/PainPoints.tsx
@@ -34,7 +34,7 @@ export default function PainPoints() {
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.5, delay: i * 0.1 }}
-            className="rounded-2xl bg-olive/60 p-6 text-center shadow-xl ring-1 ring-silver/20 backdrop-blur-md hover:shadow-2xl"
+            className="rounded-2xl bg-olive/60 p-6 text-center shadow-xl ring-1 ring-olive/20 backdrop-blur-md hover:shadow-2xl"
           >
             <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-blood/20 text-blood">
               {p.icon}

--- a/src/components/webdevLanding/Proof.tsx
+++ b/src/components/webdevLanding/Proof.tsx
@@ -40,7 +40,7 @@ export default function Proof() {
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               transition={{ duration: 0.5, delay: i * 0.1 }}
-              className="rounded-2xl bg-olive/70 p-6 shadow-xl ring-1 ring-silver/20 backdrop-blur-md hover:shadow-2xl"
+              className="rounded-2xl bg-olive/70 p-6 shadow-xl ring-1 ring-olive/20 backdrop-blur-md hover:shadow-2xl"
             >
               <p className="text-sm italic">&ldquo;{t.quote}&rdquo;</p>
               <p className="mt-4 font-semibold">{t.name}</p>

--- a/src/components/whyNpr/AiCarousel.tsx
+++ b/src/components/whyNpr/AiCarousel.tsx
@@ -66,7 +66,7 @@ export default function AiCarousel() {
                   animate={{ opacity: 1, y: 0 }}
                   exit={{ opacity: 0, y: -30 }}
                   transition={{ duration: 0.5 }}
-                  className="mx-auto w-[clamp(16rem,40vw,22rem)] space-y-4 rounded-xl border border-silver/20 bg-olive p-6 text-center text-silver shadow-2xl"
+                  className="mx-auto w-[clamp(16rem,40vw,22rem)] space-y-4 rounded-xl border border-olive/20 bg-olive p-6 text-center text-silver shadow-2xl"
                 >
                   <h2 className="text-2xl font-bold">{title}</h2>
                   <ul className="list-disc space-y-1 pl-5 text-left text-sm">

--- a/src/components/whyNpr/FirmCarousel.tsx
+++ b/src/components/whyNpr/FirmCarousel.tsx
@@ -85,7 +85,7 @@ export default function FirmCarousel() {
                   animate={{ opacity: 1, y: 0 }}
                   exit={{ opacity: 0, y: -30 }}
                   transition={{ duration: 0.5 }}
-                  className="mx-auto w-[clamp(18rem,60vw,28rem)] rounded-xl border border-silver/20 bg-gradient-to-br from-olive via-olive to-olive p-6 text-charcoal shadow-2xl"
+                  className="mx-auto w-[clamp(18rem,60vw,28rem)] rounded-xl border border-olive/20 bg-gradient-to-br from-olive via-olive to-olive p-6 text-charcoal shadow-2xl"
                 >
                   <div className="grid grid-cols-[1fr_auto_1fr_auto_1fr] items-center gap-4">
                     <div>

--- a/src/components/whyNpr/NprCarousel.tsx
+++ b/src/components/whyNpr/NprCarousel.tsx
@@ -65,7 +65,7 @@ export default function NprCarousel() {
                   animate={{ opacity: 1, x: 0 }}
                   exit={{ opacity: 0, x: -30 }}
                   transition={{ duration: 0.5 }}
-                  className="mx-auto w-[clamp(16rem,40vw,22rem)] space-y-4 rounded-xl border border-silver/20 bg-gradient-to-br from-blood via-blood to-blood p-6 text-center text-silver shadow-2xl"
+                  className="mx-auto w-[clamp(16rem,40vw,22rem)] space-y-4 rounded-xl border border-olive/20 bg-gradient-to-br from-blood via-blood to-blood p-6 text-center text-silver shadow-2xl"
                 >
                   <h2 className="text-2xl font-bold">{title}</h2>
                   <ul className="list-disc space-y-1 pl-5 text-left text-sm">

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -162,10 +162,12 @@ img {
   .bg-silver\/5 { background-color: rgb(var(--color-silver-rgb) / 0.05); }
   .bg-silver\/10 { background-color: rgb(var(--color-silver-rgb) / 0.1); }
   .bg-silver\/30 { background-color: rgb(var(--color-silver-rgb) / 0.3); }
+  .ring-blood { box-shadow: 0 0 0 2px rgb(var(--color-blood-rgb)); }
   .ring-blood\/40 { box-shadow: 0 0 0 2px rgb(var(--color-blood-rgb) / 0.4); }
   .ring-blood\/50 { box-shadow: 0 0 0 2px rgb(var(--color-blood-rgb) / 0.5); }
   .ring-olive\/10 { box-shadow: 0 0 0 1px rgb(var(--color-olive-rgb) / 0.1); }
   .ring-olive\/20 { box-shadow: 0 0 0 1px rgb(var(--color-olive-rgb) / 0.2); }
+  .ring-olive { box-shadow: 0 0 0 1px rgb(var(--color-olive-rgb)); }
   .shadow-silver\/20 { box-shadow: 0 1px 3px 0 rgb(var(--color-silver-rgb) / 0.2); }
   .shadow-silver\/40 { box-shadow: 0 2px 6px 0 rgb(var(--color-silver-rgb) / 0.4); }
   .glow-blood {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -164,8 +164,8 @@ img {
   .bg-silver\/30 { background-color: rgb(var(--color-silver-rgb) / 0.3); }
   .ring-blood\/40 { box-shadow: 0 0 0 2px rgb(var(--color-blood-rgb) / 0.4); }
   .ring-blood\/50 { box-shadow: 0 0 0 2px rgb(var(--color-blood-rgb) / 0.5); }
-  .ring-silver\/10 { box-shadow: 0 0 0 1px rgb(var(--color-silver-rgb) / 0.1); }
-  .ring-silver\/20 { box-shadow: 0 0 0 1px rgb(var(--color-silver-rgb) / 0.2); }
+  .ring-olive\/10 { box-shadow: 0 0 0 1px rgb(var(--color-olive-rgb) / 0.1); }
+  .ring-olive\/20 { box-shadow: 0 0 0 1px rgb(var(--color-olive-rgb) / 0.2); }
   .shadow-silver\/20 { box-shadow: 0 1px 3px 0 rgb(var(--color-silver-rgb) / 0.2); }
   .shadow-silver\/40 { box-shadow: 0 2px 6px 0 rgb(var(--color-silver-rgb) / 0.4); }
   .glow-blood {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -84,9 +84,12 @@ module.exports = {
     'bg-blood', 'text-blood',
     'bg-crimson', 'text-crimson',
     // Opacity variants used in the project
-    'bg-blood/20', 'bg-blood/30', 'ring-blood/40', 'ring-blood/50',
+    'bg-blood/20', 'bg-blood/30',
+    'ring-blood', 'ring-blood/40', 'ring-blood/50',
     'bg-olive/20', 'bg-olive/60', 'bg-olive/70', 'bg-olive/80',
-    'bg-silver/5', 'bg-silver/10', 'bg-silver/30', 'ring-olive/10', 'ring-olive/20', 'shadow-silver/20', 'shadow-silver/40',
+    'ring-olive', 'ring-olive/10', 'ring-olive/20',
+    'bg-silver/5', 'bg-silver/10', 'bg-silver/30',
+    'shadow-silver/20', 'shadow-silver/40',
   ],
 
   plugins: [

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -86,7 +86,7 @@ module.exports = {
     // Opacity variants used in the project
     'bg-blood/20', 'bg-blood/30', 'ring-blood/40', 'ring-blood/50',
     'bg-olive/20', 'bg-olive/60', 'bg-olive/70', 'bg-olive/80',
-    'bg-silver/5', 'bg-silver/10', 'bg-silver/30', 'ring-silver/10', 'ring-silver/20', 'shadow-silver/20', 'shadow-silver/40',
+    'bg-silver/5', 'bg-silver/10', 'bg-silver/30', 'ring-olive/10', 'ring-olive/20', 'shadow-silver/20', 'shadow-silver/40',
   ],
 
   plugins: [


### PR DESCRIPTION
## Summary
- use `border-umber` for heavy section dividers
- switch all subtle borders to `border-olive`
- update spinner borders to olive
- adjust carousel and content borders to olive tones

## Testing
- `pnpm lint`
- `pnpm check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687709dc9bc08328a6d5be8e386e9bab