### PR TITLE
Highlight tagline segments

### DIFF
--- a/src/components/common/HighlightedText.tsx
+++ b/src/components/common/HighlightedText.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import React from 'react';
+import clsx from 'clsx';
+
+export interface HighlightedSegment {
+  text: string;
+  highlight: boolean;
+}
+
+export function parseTaggedText(text: string, tag: string = 'blood'): HighlightedSegment[] {
+  const regex = new RegExp(`\\[${tag}\\](.*?)\\[\\/${tag}\\]`, 'g');
+  const segments: HighlightedSegment[] = [];
+  let lastIndex = 0;
+  let match;
+  while ((match = regex.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      segments.push({ text: text.slice(lastIndex, match.index), highlight: false });
+    }
+    segments.push({ text: match[1], highlight: true });
+    lastIndex = regex.lastIndex;
+  }
+  if (lastIndex < text.length) {
+    segments.push({ text: text.slice(lastIndex), highlight: false });
+  }
+  return segments;
+}
+
+interface HighlightedTextProps {
+  text: string;
+  tag?: string;
+  highlightClassName?: string;
+  className?: string;
+}
+
+const HighlightedText: React.FC<HighlightedTextProps> = ({
+  text,
+  tag = 'blood',
+  highlightClassName = 'text-blood glow-blood',
+  className,
+}) => {
+  const segments = parseTaggedText(text, tag);
+  return (
+    <span className={className}>
+      {segments.map((seg, idx) => (
+        <span key={idx} className={clsx(seg.highlight && highlightClassName)}>
+          {seg.text}
+        </span>
+      ))}
+    </span>
+  );
+};
+
+export default HighlightedText;

--- a/src/components/common/HighlightedText.tsx
+++ b/src/components/common/HighlightedText.tsx
@@ -8,21 +8,27 @@ export interface HighlightedSegment {
   highlight: boolean;
 }
 
-export function parseTaggedText(text: string, tag: string = 'blood'): HighlightedSegment[] {
+export function parseTaggedText(
+  text: string,
+  tag: string = 'blood',
+): HighlightedSegment[] {
   const regex = new RegExp(`\\[${tag}\\](.*?)\\[\\/${tag}\\]`, 'g');
   const segments: HighlightedSegment[] = [];
   let lastIndex = 0;
-  let match;
-  while ((match = regex.exec(text)) !== null) {
-    if (match.index > lastIndex) {
-      segments.push({ text: text.slice(lastIndex, match.index), highlight: false });
+
+  for (const match of text.matchAll(regex)) {
+    const index = match.index ?? 0;
+    if (index > lastIndex) {
+      segments.push({ text: text.slice(lastIndex, index), highlight: false });
     }
     segments.push({ text: match[1], highlight: true });
-    lastIndex = regex.lastIndex;
+    lastIndex = index + match[0].length;
   }
+
   if (lastIndex < text.length) {
     segments.push({ text: text.slice(lastIndex), highlight: false });
   }
+
   return segments;
 }
 

--- a/src/components/homepage/Hero.tsx
+++ b/src/components/homepage/Hero.tsx
@@ -208,15 +208,18 @@ const HeroSection: React.FC<HeroProps> = ({ headline, subheadline, ctaText, ctaL
             data-scroll
             variants={textVariants}
             custom={1}
-            className="glow-blood mb-6 w-full text-charcoal bg-gradient-to-r from-blood to-crimson bg-clip-text text-[clamp(2.5rem,6vw,4.5rem)] leading-[1.1] font-grotesk font-bold tracking-tight"
+            className="glow-blood mb-6 w-full text-charcoal text-[clamp(2.5rem,6vw,4.5rem)] leading-[1.1] font-grotesk font-bold tracking-tight"
           >
             {(() => {
               let idx = 0;
-              return headlineSegments.map((seg, si) => (
-                <span key={si} className="block overflow-hidden">
-                  {seg.text.trim().split(/\s+/).map((word) => {
+              const words: React.ReactNode[] = [];
+              headlineSegments.forEach((seg) => {
+                seg.text
+                  .trim()
+                  .split(/\s+/)
+                  .forEach((word) => {
                     const current = idx++;
-                    return (
+                    words.push(
                       <motion.span
                         key={current}
                         className={clsx('inline-block', seg.highlight ? 'text-blood' : 'text-charcoal')}
@@ -226,9 +229,9 @@ const HeroSection: React.FC<HeroProps> = ({ headline, subheadline, ctaText, ctaL
                         {word}&nbsp;
                       </motion.span>
                     );
-                  })}
-                </span>
-              ));
+                  });
+              });
+              return words;
             })()}
           </motion.h1>
           {subheadline && (

--- a/src/components/homepage/Hero.tsx
+++ b/src/components/homepage/Hero.tsx
@@ -8,7 +8,7 @@ import { ShieldCheck, ChevronDown } from 'lucide-react';
 import { motion, useAnimation, useReducedMotion, useScroll, useTransform } from 'framer-motion';
 import { useParticleBackground } from '@/lib/hooks/useParticleBackground';
 import { useHeroAnalytics } from '@/lib/hooks/useHeroAnalytics';
-import { parseTaggedText } from '../common/HighlightedText';
+import { parseTaggedText } from '@/components/common/HighlightedText';
 
 
 interface HeroProps {

--- a/src/components/homepage/Hero.tsx
+++ b/src/components/homepage/Hero.tsx
@@ -197,7 +197,7 @@ const HeroSection: React.FC<HeroProps> = ({ headline, subheadline, ctaText, ctaL
             {headlineSegments.map((seg, si) => (
               <motion.span
                 key={si}
-                className={clsx(seg.highlight ? 'text-blood glow-blood' : 'text-charcoal')}
+                className={clsx('inline-block', seg.highlight ? 'text-blood glow-blood' : 'text-charcoal')}
                 variants={wordVariants}
                 custom={si}
               >

--- a/src/components/homepage/Hero.tsx
+++ b/src/components/homepage/Hero.tsx
@@ -210,29 +210,16 @@ const HeroSection: React.FC<HeroProps> = ({ headline, subheadline, ctaText, ctaL
             custom={1}
             className="glow-blood mb-6 w-full text-charcoal text-[clamp(2.5rem,6vw,4.5rem)] leading-[1.1] font-grotesk font-bold tracking-tight"
           >
-            {(() => {
-              let idx = 0;
-              const words: React.ReactNode[] = [];
-              headlineSegments.forEach((seg) => {
-                seg.text
-                  .trim()
-                  .split(/\s+/)
-                  .forEach((word) => {
-                    const current = idx++;
-                    words.push(
-                      <motion.span
-                        key={current}
-                        className={clsx('inline-block', seg.highlight ? 'text-blood' : 'text-charcoal')}
-                        variants={wordVariants}
-                        custom={current}
-                      >
-                        {word}&nbsp;
-                      </motion.span>
-                    );
-                  });
-              });
-              return words;
-            })()}
+            {headlineSegments.map((seg, si) => (
+              <motion.span
+                key={si}
+                className={clsx(seg.highlight ? 'text-blood' : 'text-charcoal')}
+                variants={wordVariants}
+                custom={si}
+              >
+                {seg.text}
+              </motion.span>
+            ))}
           </motion.h1>
           {subheadline && (
             <motion.p

--- a/src/components/homepage/Hero.tsx
+++ b/src/components/homepage/Hero.tsx
@@ -208,12 +208,12 @@ const HeroSection: React.FC<HeroProps> = ({ headline, subheadline, ctaText, ctaL
             data-scroll
             variants={textVariants}
             custom={1}
-            className="glow-blood mb-6 w-full text-charcoal text-[clamp(2.5rem,6vw,4.5rem)] leading-[1.1] font-grotesk font-bold tracking-tight"
+            className="mb-6 w-full text-charcoal text-[clamp(2.5rem,6vw,4.5rem)] leading-[1.1] font-grotesk font-bold tracking-tight"
           >
             {headlineSegments.map((seg, si) => (
               <motion.span
                 key={si}
-                className={clsx(seg.highlight ? 'text-blood' : 'text-charcoal')}
+                className={clsx(seg.highlight ? 'text-blood glow-blood' : 'text-charcoal')}
                 variants={wordVariants}
                 custom={si}
               >

--- a/src/components/homepage/Hero.tsx
+++ b/src/components/homepage/Hero.tsx
@@ -8,24 +8,8 @@ import { ShieldCheck, ChevronDown } from 'lucide-react';
 import { motion, useAnimation, useReducedMotion, useScroll, useTransform } from 'framer-motion';
 import { useParticleBackground } from '@/lib/hooks/useParticleBackground';
 import { useHeroAnalytics } from '@/lib/hooks/useHeroAnalytics';
+import { parseTaggedText } from '../common/HighlightedText';
 
-function parseHeadline(text: string) {
-  const regex = /\[blood\](.*?)\[\/blood\]/g;
-  const segments: { text: string; highlight: boolean }[] = [];
-  let lastIndex = 0;
-  let match;
-  while ((match = regex.exec(text)) !== null) {
-    if (match.index > lastIndex) {
-      segments.push({ text: text.slice(lastIndex, match.index), highlight: false });
-    }
-    segments.push({ text: match[1], highlight: true });
-    lastIndex = regex.lastIndex;
-  }
-  if (lastIndex < text.length) {
-    segments.push({ text: text.slice(lastIndex), highlight: false });
-  }
-  return segments;
-}
 
 interface HeroProps {
   headline: string;
@@ -172,7 +156,7 @@ const HeroSection: React.FC<HeroProps> = ({ headline, subheadline, ctaText, ctaL
     },
   };
   const rawHeadline = personalizedHeadline || headline;
-  const headlineSegments = parseHeadline(rawHeadline);
+  const headlineSegments = parseTaggedText(rawHeadline);
 
   return (
     <motion.section

--- a/src/content/homepage/hero.ts
+++ b/src/content/homepage/hero.ts
@@ -15,7 +15,7 @@ export interface HeroProps {
 
 export const hero: HeroProps = {
   headline:
-    '[blood]Trusted by[/blood] [blood]Founders Who Don\u2019t Get a[/blood] [blood]Second Shot.[/blood]',
+    '[blood]Trusted by[/blood] [blood]Founders Who Don’t Get a[/blood] [blood]Second Shot.[/blood]',
   subheadline: '70% of startups fail between years 2–5 — a weak website is one of the fastest ways to join them.',
   ctaText: 'Make Sure Your Website Isn’t the Reason',
   ctaLink: '/webdev-landing',

--- a/src/content/homepage/hero.ts
+++ b/src/content/homepage/hero.ts
@@ -14,7 +14,8 @@ export interface HeroProps {
 }
 
 export const hero: HeroProps = {
-  headline: 'Trusted by Founders Who Don’t Get a Second Shot.',
+  headline:
+    '[blood]Trusted by[/blood] [blood]Founders Who Don\u2019t Get a[/blood] [blood]Second Shot.[/blood]',
   subheadline: '70% of startups fail between years 2–5 — a weak website is one of the fastest ways to join them.',
   ctaText: 'Make Sure Your Website Isn’t the Reason',
   ctaLink: '/webdev-landing',


### PR DESCRIPTION
## Summary
- emphasize main tagline phrases using a `[blood]` tag
- parse these tags in the homepage Hero component

## Testing
- `npx next lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68772ec4b22883289d135869b8c65a60