### PR TITLE
Ensure text-blood only via tag

### DIFF
--- a/src/components/common/HighlightedText.tsx
+++ b/src/components/common/HighlightedText.tsx
@@ -36,6 +36,7 @@ interface HighlightedTextProps {
   text: string;
   tag?: string;
   highlightClassName?: string;
+  defaultClassName?: string;
   className?: string;
 }
 
@@ -43,13 +44,20 @@ const HighlightedText: React.FC<HighlightedTextProps> = ({
   text,
   tag = 'blood',
   highlightClassName = 'text-blood glow-blood',
+  defaultClassName = 'text-charcoal',
   className,
 }) => {
   const segments = parseTaggedText(text, tag);
   return (
     <span className={className}>
       {segments.map((seg, idx) => (
-        <span key={idx} className={clsx(seg.highlight && highlightClassName)}>
+        <span
+          key={idx}
+          className={clsx(
+            'inline',
+            seg.highlight ? highlightClassName : defaultClassName,
+          )}
+        >
           {seg.text}
         </span>
       ))}


### PR DESCRIPTION
## Summary
- enforce text-charcoal as default styling in `HighlightedText`
- keep parseTaggedText returning highlight booleans

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_687865e28134832887aad8b0b28acf38