### PR TITLE
Ensure default color for untagged segments

### DIFF
--- a/src/components/common/HighlightedText.tsx
+++ b/src/components/common/HighlightedText.tsx
@@ -36,6 +36,9 @@ interface HighlightedTextProps {
   text: string;
   tag?: string;
   highlightClassName?: string;
+  /** class applied to non-highlighted segments */
+  defaultClassName?: string;
+  /** wrapper element class */
   className?: string;
 }
 
@@ -43,13 +46,17 @@ const HighlightedText: React.FC<HighlightedTextProps> = ({
   text,
   tag = 'blood',
   highlightClassName = 'text-blood glow-blood',
+  defaultClassName = 'text-charcoal',
   className,
 }) => {
   const segments = parseTaggedText(text, tag);
   return (
     <span className={className}>
       {segments.map((seg, idx) => (
-        <span key={idx} className={clsx(seg.highlight && highlightClassName)}>
+        <span
+          key={idx}
+          className={clsx('inline', seg.highlight ? highlightClassName : defaultClassName)}
+        >
           {seg.text}
         </span>
       ))}


### PR DESCRIPTION
## Summary
- specify `defaultClassName` in `HighlightedText` and apply `text-charcoal` for non-highlighted text
- keep hero headline mapping with explicit text colours

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_687865e28134832887aad8b0b28acf38