### PR TITLE
Ensure non-highlighted text shows charcoal color

### DIFF
--- a/src/components/common/HighlightedText.tsx
+++ b/src/components/common/HighlightedText.tsx
@@ -36,6 +36,11 @@ interface HighlightedTextProps {
   text: string;
   tag?: string;
   highlightClassName?: string;
+  /**
+   * Class applied to non-highlighted segments. Defaults to `text-charcoal`
+   * so text color is always explicitly set and never inherits unwanted styles.
+   */
+  defaultClassName?: string;
   className?: string;
 }
 
@@ -43,13 +48,17 @@ const HighlightedText: React.FC<HighlightedTextProps> = ({
   text,
   tag = 'blood',
   highlightClassName = 'text-blood glow-blood',
+  defaultClassName = 'text-charcoal',
   className,
 }) => {
   const segments = parseTaggedText(text, tag);
   return (
     <span className={className}>
       {segments.map((seg, idx) => (
-        <span key={idx} className={clsx(seg.highlight && highlightClassName)}>
+        <span
+          key={idx}
+          className={clsx('inline', seg.highlight ? highlightClassName : defaultClassName)}
+        >
           {seg.text}
         </span>
       ))}


### PR DESCRIPTION
## Summary
- enforce explicit coloring in `HighlightedText` segments
- update docs and props for non-highlighted text handling

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_687865e28134832887aad8b0b28acf38