### PR TITLE
Add grayscale hero reveal animation

### DIFF
--- a/src/components/homepage/Hero.tsx
+++ b/src/components/homepage/Hero.tsx
@@ -11,7 +11,7 @@ import { useParticleBackground } from '@/lib/hooks/useParticleBackground';
 import { useHeroAnalytics } from '@/lib/hooks/useHeroAnalytics';
 import { parseTaggedText } from '@/components/common/HighlightedText';
 
-interface HeroProps {
+export interface HeroProps {
   headline: string;
   subheadline?: string;
   ctaText?: string;
@@ -24,12 +24,23 @@ interface HeroProps {
   };
 }
 
-const HeroSection: React.FC<HeroProps> = ({ headline, subheadline, ctaText, ctaLink, image }) => {
+export function HeroContent({
+  headline,
+  subheadline,
+  ctaText,
+  ctaLink,
+  image,
+  forceGray = false,
+  enableEffects = true,
+}: HeroProps & { forceGray?: boolean; enableEffects?: boolean }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const heroRef = useRef<HTMLElement>(null);
   const overlayRef = useRef<HTMLDivElement>(null);
   const ctaRef = useRef<HTMLButtonElement>(null);
   const router = useRouter();
+  const disabledContainerRef = useRef<HTMLDivElement>(null);
+  const disabledHeroRef = useRef<HTMLElement>(null);
+  const disabledCtaRef = useRef<HTMLButtonElement>(null);
 
   const { scrollYProgress } = useScroll({
     target: heroRef,
@@ -51,8 +62,11 @@ const HeroSection: React.FC<HeroProps> = ({ headline, subheadline, ctaText, ctaL
   const [isStickyVisible, setIsStickyVisible] = useState(false);
   const [personalizedHeadline, setPersonalizedHeadline] = useState('');
 
-  useParticleBackground(containerRef);
-  useHeroAnalytics({ heroRef, ctaRef });
+  useParticleBackground(enableEffects ? containerRef : disabledContainerRef);
+  useHeroAnalytics({
+    heroRef: enableEffects ? heroRef : disabledHeroRef,
+    ctaRef: enableEffects ? ctaRef : disabledCtaRef,
+  });
 
 
   useEffect(() => {
@@ -78,7 +92,7 @@ const HeroSection: React.FC<HeroProps> = ({ headline, subheadline, ctaText, ctaL
   }, [searchParams]);
 
   useEffect(() => {
-    if (prefersReducedMotion) return;
+    if (prefersReducedMotion || !enableEffects) return;
 
     const original = document.body.style.overflow;
     document.body.style.overflow = 'hidden';
@@ -90,10 +104,11 @@ const HeroSection: React.FC<HeroProps> = ({ headline, subheadline, ctaText, ctaL
     return () => {
       document.body.style.overflow = original;
     };
-  }, [controls, prefersReducedMotion]);
+  }, [controls, prefersReducedMotion, enableEffects]);
 
 
   useEffect(() => {
+    if (!enableEffects) return;
     let timer: NodeJS.Timeout;
     const onScroll = () => {
       setIsStickyVisible(false);
@@ -105,7 +120,7 @@ const HeroSection: React.FC<HeroProps> = ({ headline, subheadline, ctaText, ctaL
       clearTimeout(timer);
       window.removeEventListener('scroll', onScroll);
     };
-  }, []);
+  }, [enableEffects]);
 
   const textVariants = {
     hidden: { opacity: 0, y: 15 },
@@ -199,7 +214,16 @@ const HeroSection: React.FC<HeroProps> = ({ headline, subheadline, ctaText, ctaL
             {headlineSegments.map((seg, si) => (
               <motion.span
                 key={si}
-                className={clsx('inline-block', seg.highlight ? 'text-blood glow-blood' : 'text-charcoal')}
+                className={clsx(
+                  'inline-block transition-colors duration-700',
+                  forceGray
+                    ? seg.text.trim() === 'Trusted by'
+                      ? 'text-blood glow-blood filter-none'
+                      : 'text-gray-400 filter grayscale'
+                    : seg.highlight
+                      ? 'text-blood glow-blood'
+                      : 'text-charcoal'
+                )}
                 variants={wordVariants}
                 custom={si}
               >
@@ -333,4 +357,27 @@ const HeroSection: React.FC<HeroProps> = ({ headline, subheadline, ctaText, ctaL
   );
 };
 
-export default HeroSection;
+export default function HeroSection(props: HeroProps) {
+  const [reveal, setReveal] = useState(false);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => setReveal(true), 500);
+    return () => clearTimeout(timeout);
+  }, []);
+
+  return (
+    <div className="relative w-full overflow-hidden">
+      <div className="absolute inset-0 grayscale z-10 pointer-events-none">
+        <HeroContent {...props} forceGray enableEffects={false} />
+      </div>
+      <div
+        className={clsx(
+          'relative z-20 transition-[clip-path] duration-[2000ms] ease-in-out',
+          reveal ? 'clip-reveal-full' : 'clip-reveal-hidden'
+        )}
+      >
+        <HeroContent {...props} />
+      </div>
+    </div>
+  );
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -286,6 +286,12 @@ img {
   .logo-hover:hover::after {
     width: 50%;
   }
+  .clip-reveal-hidden {
+    clip-path: polygon(0 100%, 0 100%, 0 100%, 0 100%);
+  }
+  .clip-reveal-full {
+    clip-path: polygon(0 100%, 100% 0, 100% 0, 0 100%);
+  }
 }
 
 @keyframes glow-pulse {


### PR DESCRIPTION
## Summary
- implement HeroContent component with grayscale option
- overlay hero in grayscale and animate diagonal reveal
- define clip-path utilities for reveal effect

## Testing
- `pnpm lint`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_6879779e49d48328aee670a0e5cd2f74