### PR TITLE
Display Trusted by in color during grayscale stage

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -3,6 +3,7 @@
 :root, :host {
   --font-sans: ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
     'Noto Color Emoji';
+  --color-gray-400: oklch(70.7% 0.022 261.325);
   --color-black: #000;
   --color-white: #fff;
   --spacing: 0.25rem;
@@ -55,6 +56,9 @@
 }
 .pointer-events-none {
   pointer-events: none;
+}
+.invisible {
+  visibility: hidden;
 }
 .visible {
   visibility: visible;
@@ -712,6 +716,9 @@
   --tw-gradient-position: to top in oklab;
   background-image: linear-gradient(var(--tw-gradient-stops));
 }
+.\[background-image\:radial-gradient\(circle\,rgba\(0\,0\,0\,0\.05\)_1px\,transparent_1px\)\] {
+  background-image: radial-gradient(circle,rgba(0,0,0,0.05) 1px,transparent 1px);
+}
 .bg-\[linear-gradient\(270deg\,var\(--tw-gradient-stops\)\)\] {
   background-image: linear-gradient(270deg,var(--tw-gradient-stops));
 }
@@ -753,12 +760,11 @@
   --tw-gradient-to: transparent;
   --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
 }
+.\[background-size\:3px_3px\] {
+  background-size: 3px 3px;
+}
 .bg-cover {
   background-size: cover;
-}
-.bg-clip-text {
-  -webkit-background-clip: text;
-          background-clip: text;
 }
 .bg-center {
   background-position: center;
@@ -961,8 +967,8 @@
 .text-\[0\.65rem\] {
   font-size: 0.65rem;
 }
-.text-\[33vh\] {
-  font-size: 33vh;
+.text-\[45vh\] {
+  font-size: 45vh;
 }
 .text-\[clamp\(0\.7rem\,1vw\,0\.8rem\)\] {
   font-size: clamp(0.7rem, 1vw, 0.8rem);
@@ -1091,6 +1097,9 @@
   --tw-tracking: var(--tracking-widest);
   letter-spacing: var(--tracking-widest);
 }
+.text-gray-400 {
+  color: var(--color-gray-400);
+}
 .text-transparent {
   color: transparent;
 }
@@ -1126,6 +1135,9 @@
 }
 .opacity-30 {
   opacity: 30%;
+}
+.opacity-40 {
+  opacity: 40%;
 }
 .opacity-70 {
   opacity: 70%;
@@ -1190,12 +1202,19 @@
   --tw-blur: blur(var(--blur-3xl));
   filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
 }
+.grayscale {
+  --tw-grayscale: grayscale(100%);
+  filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
+}
 .sepia {
   --tw-sepia: sepia(100%);
   filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
 }
 .filter {
   filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
+}
+.filter-none {
+  filter: none;
 }
 .backdrop-blur {
   --tw-backdrop-blur: blur(8px);
@@ -1209,6 +1228,11 @@
 }
 .transition {
   transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to, opacity, box-shadow, transform, translate, scale, rotate, filter, -webkit-backdrop-filter, backdrop-filter, display, visibility, content-visibility, overlay, pointer-events;
+  transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+  transition-duration: var(--tw-duration, var(--default-transition-duration));
+}
+.transition-\[clip-path\] {
+  transition-property: clip-path;
   transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
   transition-duration: var(--tw-duration, var(--default-transition-duration));
 }
@@ -1248,6 +1272,14 @@
 .duration-500 {
   --tw-duration: 500ms;
   transition-duration: 500ms;
+}
+.duration-700 {
+  --tw-duration: 700ms;
+  transition-duration: 700ms;
+}
+.duration-\[2000ms\] {
+  --tw-duration: 2000ms;
+  transition-duration: 2000ms;
 }
 .ease-in-out {
   --tw-ease: var(--ease-in-out);
@@ -1987,6 +2019,12 @@ img {
   .logo-hover:hover::after {
     width: 50%;
   }
+}
+.clip-reveal-hidden {
+  clip-path: polygon(0 100%, 0 100%, 0 100%, 0 100%);
+}
+.clip-reveal-full {
+  clip-path: polygon(0 100%, 100% 100%, 100% 0, 0 0);
 }
 @keyframes glow-pulse {
   0%, 100% {

--- a/src/components/homepage/Hero.tsx
+++ b/src/components/homepage/Hero.tsx
@@ -32,7 +32,8 @@ export function HeroContent({
   image,
   forceGray = false,
   enableEffects = true,
-}: HeroProps & { forceGray?: boolean; enableEffects?: boolean }) {
+  hideCue = false,
+}: HeroProps & { forceGray?: boolean; enableEffects?: boolean; hideCue?: boolean }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const heroRef = useRef<HTMLElement>(null);
   const overlayRef = useRef<HTMLDivElement>(null);
@@ -172,7 +173,6 @@ export function HeroContent({
   };
   const rawHeadline = personalizedHeadline || headline;
   const headlineSegments = parseTaggedText(rawHeadline);
-  console.log('Parsed headline segments →', headlineSegments);
 
 
   return (
@@ -192,14 +192,17 @@ export function HeroContent({
 
       <motion.div
         className="relative z-10 mx-auto grid w-full max-w-[88rem] grid-cols-1 items-center gap-[clamp(2rem,6vw,5rem)] px-[clamp(1rem,4vw,2rem)] pt-[clamp(1rem,5vw,3rem)] pb-[clamp(4rem,8vw,6rem)] md:grid-cols-2"
-        initial="hidden"
-        animate={controls}
+        initial={enableEffects ? 'hidden' : 'visible'}
+        animate={enableEffects ? controls : 'visible'}
       >
         <div className="px-0">
         <motion.div
           variants={textVariants}
           custom={0}
-          className="mb-6 text-[clamp(0.85rem,1.2vw,0.9rem)] font-thin tracking-widest text-charcoal"
+          className={clsx(
+            'mb-6 text-[clamp(0.85rem,1.2vw,0.9rem)] font-thin tracking-widest text-charcoal',
+            forceGray && 'text-gray-400 filter grayscale'
+          )}
         >
           HELLO, WE ARE NPR MEDIA
         </motion.div>
@@ -211,32 +214,42 @@ export function HeroContent({
             custom={1}
             className="mb-6 w-full text-charcoal text-[clamp(2.5rem,6vw,4.5rem)] leading-[1.1] font-grotesk font-bold tracking-tight"
           >
-            {headlineSegments.map((seg, si) => (
-              <motion.span
-                key={si}
-                className={clsx(
-                  'inline-block transition-colors duration-700',
-                  forceGray
-                    ? seg.text.trim() === 'Trusted by'
-                      ? 'text-blood glow-blood filter-none'
-                      : 'text-gray-400 filter grayscale'
-                    : seg.highlight
-                      ? 'text-blood glow-blood'
-                      : 'text-charcoal'
-                )}
-                variants={wordVariants}
-                custom={si}
-              >
-                {seg.text}
-              </motion.span>
-            ))}
+            {headlineSegments.map((seg, si) => {
+              const isTrusted = seg.text.trim() === 'Trusted by';
+              const Span = enableEffects && !isTrusted ? motion.span : 'span';
+              const spanProps =
+                enableEffects && !isTrusted
+                  ? { variants: wordVariants, custom: si }
+                  : {};
+              return (
+                <Span
+                  key={si}
+                  {...spanProps}
+                  className={clsx(
+                    'inline-block transition-colors duration-700',
+                    forceGray
+                      ? isTrusted
+                        ? 'text-blood glow-blood filter-none'
+                        : 'text-gray-400 filter grayscale'
+                      : seg.highlight
+                        ? 'text-blood glow-blood'
+                        : 'text-charcoal'
+                  )}
+                >
+                  {seg.text}
+                </Span>
+              );
+            })}
           </motion.h1>
           {subheadline && (
             <motion.p
               id="hero-subheadline"
               aria-describedby="hero-headline"
               variants={subheadlineVariants}
-              className="font-grotesk font-medium text-charcoal opacity-90 md:opacity-100 mt-6 sm:mt-8 lg:mt-10 mb-7 mx-auto max-w-[60ch] text-center text-[clamp(1rem,1.5vw,1.25rem)] leading-[1.6]"
+              className={clsx(
+                'font-grotesk font-medium text-charcoal opacity-90 md:opacity-100 mt-6 sm:mt-8 lg:mt-10 mb-7 mx-auto max-w-[60ch] text-center text-[clamp(1rem,1.5vw,1.25rem)] leading-[1.6]',
+                forceGray && 'text-gray-400 filter grayscale'
+              )}
             >
               {subheadline}
             </motion.p>
@@ -251,7 +264,10 @@ export function HeroContent({
                 ref={ctaRef}
                 aria-label="Start your project with NPR Media"
                 onClick={() => router.push(ctaLink)}
-                className="cta-glow ripple-hover inline-flex items-center justify-center rounded-full border border-blood bg-blood px-[clamp(1.875rem,3.75vw,2.5rem)] py-[clamp(0.9rem,1.5vw,1.25rem)] text-[clamp(0.875rem,1vw,1rem)] font-bold uppercase tracking-wide text-silver shadow-[0_0_20px_rgba(179,0,0,0.2)] transition-transform duration-300 hover:scale-105 hover:bg-crimson focus-visible:outline focus-visible:outline-crimson"
+                className={clsx(
+                  'cta-glow ripple-hover inline-flex items-center justify-center rounded-full border border-blood bg-blood px-[clamp(1.875rem,3.75vw,2.5rem)] py-[clamp(0.9rem,1.5vw,1.25rem)] text-[clamp(0.875rem,1vw,1rem)] font-bold uppercase tracking-wide text-silver shadow-[0_0_20px_rgba(179,0,0,0.2)] transition-transform duration-300 hover:scale-105 hover:bg-crimson focus-visible:outline focus-visible:outline-crimson',
+                  forceGray && 'filter-none'
+                )}
               >
                 <span>{ctaText}</span>
                 <motion.span
@@ -272,7 +288,10 @@ export function HeroContent({
             role="note"
             aria-label="SOC2 certified and founder-backed"
             variants={badgeVariants}
-            className="mt-6 sm:mt-8 text-center sm:text-left flex items-center justify-center sm:justify-start text-olive text-[clamp(0.75rem,0.9vw,0.875rem)] font-medium uppercase tracking-wider font-smallcaps"
+            className={clsx(
+              'mt-6 sm:mt-8 text-center sm:text-left flex items-center justify-center sm:justify-start text-olive text-[clamp(0.75rem,0.9vw,0.875rem)] font-medium uppercase tracking-wider font-smallcaps',
+              forceGray && 'filter grayscale'
+            )}
           >
             <ShieldCheck className="mr-2 h-4 w-4 flex-shrink-0" />
             <span>SOC2 Certified • GDPR Ready • Trusted by 10,000+ users</span>
@@ -289,7 +308,7 @@ export function HeroContent({
           style={{ y: overlayY, willChange: 'transform' }}
           initial="hidden"
           animate="visible"
-          className="flex h-[200%] flex-col items-center pb-[5vh]"
+          className={clsx('flex h-[200%] flex-col items-center pb-[5vh]', forceGray && 'filter grayscale')}
         >
           {['N', 'P', 'R'].map((letter) => (
             <motion.span
@@ -308,7 +327,10 @@ export function HeroContent({
       <motion.div
         variants={textVariants}
         custom={2.5}
-        className="group absolute left-1/2 z-30 w-full max-w-[clamp(22rem,38vw,38rem)] -translate-x-1/2 transform hover:scale-105 md:left-[74%] md:transform-none"
+        className={clsx(
+          'group absolute left-1/2 z-30 w-full max-w-[clamp(22rem,38vw,38rem)] -translate-x-1/2 transform hover:scale-105 md:left-[74%] md:transform-none',
+          forceGray && 'filter grayscale'
+        )}
         style={{
           bottom: '28%',
           filter: 'contrast(0.85) brightness(1.05)',
@@ -322,7 +344,7 @@ export function HeroContent({
               alt={image.alt || 'Product Screenshot'}
               width={image.width || 480}
               height={image.height || 480}
-              className="h-auto w-full rounded-xl shadow-2xl"
+              className={clsx('h-auto w-full rounded-xl shadow-2xl', forceGray && 'grayscale')}
               priority
             />
           )}
@@ -334,7 +356,8 @@ export function HeroContent({
 
       </motion.div>
 
-      <motion.button
+      {!hideCue && (
+        <motion.button
         aria-label="Scroll to next section"
         onClick={() =>
           document
@@ -346,7 +369,8 @@ export function HeroContent({
         className="absolute bottom-[2vh] left-1/2 z-20 -translate-x-1/2 appearance-none border-none bg-transparent p-2 text-blood opacity-70 transition hover:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blood"
       >
         <ChevronDown className="h-[clamp(1.5rem,2vw,2rem)] w-[clamp(1.5rem,2vw,2rem)] animate-[bounce_2.5s_infinite]" />
-      </motion.button>
+        </motion.button>
+      )}
 
       {isStickyVisible && (
         <div className="fixed bottom-36 left-1/2 z-50 -translate-x-1/2 rounded-full bg-blood px-4 py-2 text-sm font-bold text-charcoal opacity-90 shadow-xl hover:scale-105 hover:bg-blood">
@@ -359,24 +383,57 @@ export function HeroContent({
 
 export default function HeroSection(props: HeroProps) {
   const [reveal, setReveal] = useState(false);
+  const overlaySegments = parseTaggedText(props.headline);
+  const prefersReducedMotion = useReducedMotion();
 
   useEffect(() => {
-    const timeout = setTimeout(() => setReveal(true), 1800);
+    if (prefersReducedMotion) {
+      setReveal(true);
+      return;
+    }
+    const timeout = setTimeout(() => setReveal(true), 1500);
     return () => clearTimeout(timeout);
-  }, []);
+  }, [prefersReducedMotion]);
 
   return (
     <div className="relative w-full overflow-hidden">
-      <div className="absolute inset-0 grayscale z-10 pointer-events-none">
-        <HeroContent {...props} forceGray enableEffects={false} />
+      <div className="absolute inset-0 z-10 pointer-events-none">
+        <div className="absolute inset-0 opacity-40 [background-image:radial-gradient(circle,rgba(0,0,0,0.05)_1px,transparent_1px)] [background-size:3px_3px]" />
+        <HeroContent {...props} forceGray enableEffects={false} hideCue />
       </div>
+      <motion.div
+        className="absolute inset-0 z-20 pointer-events-none"
+        initial={{ opacity: 1 }}
+        animate={{ opacity: reveal ? 0 : 1, transition: { duration: 0.6 } }}
+      >
+        <div className="relative mx-auto grid w-full max-w-[88rem] grid-cols-1 items-center gap-[clamp(2rem,6vw,5rem)] px-[clamp(1rem,4vw,2rem)] pt-[clamp(1rem,5vw,3rem)] pb-[clamp(4rem,8vw,6rem)] md:grid-cols-2">
+          <div className="px-0">
+            <div className="mb-6 text-[clamp(0.85rem,1.2vw,0.9rem)] font-thin tracking-widest text-charcoal invisible">
+              HELLO, WE ARE NPR MEDIA
+            </div>
+            <h1 className="mb-6 w-full text-blood text-[clamp(2.5rem,6vw,4.5rem)] leading-[1.1] font-grotesk font-bold tracking-tight">
+              {overlaySegments.map((seg, i) => (
+                <span
+                  key={i}
+                  className={clsx(
+                    seg.text.trim() === 'Trusted by' ? 'text-blood' : 'text-transparent'
+                  )}
+                >
+                  {seg.text}
+                </span>
+              ))}
+            </h1>
+          </div>
+        </div>
+      </motion.div>
       <div
         className={clsx(
           'relative z-20 transition-[clip-path] duration-[2000ms] ease-in-out',
           reveal ? 'clip-reveal-full' : 'clip-reveal-hidden',
         )}
+        style={{ willChange: 'clip-path' }}
       >
-        <HeroContent {...props} />
+        <HeroContent {...props} hideCue={!reveal} />
       </div>
     </div>
   );

--- a/src/content/homepage/hero.ts
+++ b/src/content/homepage/hero.ts
@@ -15,8 +15,8 @@ export interface HeroProps {
 
 export const hero: HeroProps = {
   headline: 'Trusted by [blood]Founders Who Don’t Get a[/blood] [blood]Second Shot.[/blood]',
-  subheadline: '70% of startups fail between years 2–5 — a weak website is one of the fastest ways to join them.',
-  ctaText: 'Make Sure Your Website Isn’t the Reason',
+  subheadline: "We build websites that don't fail — you won't get a second chance.",
+  ctaText: 'Book a Demo',
   ctaLink: '/webdev-landing',
   // Preview image removed to avoid bundling binary assets
 };


### PR DESCRIPTION
## Summary
- overlay heading fades out once colors reveal
- show hero overlay without global grayscale so CTA retains color
- disable animation on "Trusted by" and hide scroll cue until reveal

## Testing
- `npx next lint`
- `pnpm build:css`


------
https://chatgpt.com/codex/tasks/task_e_6879be4beff08328a36fb08ddf42c96a