### PR TITLE
Extend grayscale reveal to header

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { Suspense } from 'react';
+import React, { Suspense, useEffect, useState } from 'react';
 import { usePathname } from 'next/navigation';
 import StickyHeader from '@/components/global/Header';
 import HeroSection from '@/components/homepage/Hero';
@@ -12,13 +12,19 @@ import ContactSection from '@/components/homepage/ContactSection';
 
 export default function Page() {
   const pathname = usePathname();
+  const [reveal, setReveal] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setReveal(true), 1600);
+    return () => clearTimeout(timer);
+  }, []);
 
   return (
     <section>
-      <StickyHeader light />
+      <StickyHeader light forceGray={!reveal} />
       <main key={pathname} className="relative w-full overflow-x-hidden bg-antique text-charcoal">
         <Suspense>
-          <HeroSection {...hero} />
+          <HeroSection {...hero} reveal={reveal} />
         </Suspense>
         <IndustryTemplatesSection />
         <PricingSection />

--- a/src/components/global/Header.tsx
+++ b/src/components/global/Header.tsx
@@ -13,9 +13,11 @@ interface HeaderProps {
    * Useful on pages with light backgrounds so links remain visible.
    */
   light?: boolean;
+  /** When true, apply a grayscale filter to the entire header */
+  forceGray?: boolean;
 }
 
-export default function StickyHeader({ light = false }: HeaderProps) {
+export default function StickyHeader({ light = false, forceGray = false }: HeaderProps) {
   const [scrolled, setScrolled] = useState(false);
   const [progress, setProgress] = useState(0);
   const [menuOpen, setMenuOpen] = useState(false);
@@ -76,11 +78,11 @@ export default function StickyHeader({ light = false }: HeaderProps) {
         initial={{ y: -80, opacity: 0 }}
         animate={{ y: 0, opacity: 1 }}
         transition={{ duration: 0.6 }}
-        className={`w-full transition-all duration-500 ease-in-out ${
+        className={`w-full transition-all duration-500 ease-in-out transition-[filter] duration-[2000ms] ${
           scrolled
             ? 'bg-sepia/80 shadow-md backdrop-blur-md rounded-b-lg'
             : 'bg-transparent backdrop-blur-0'
-        } ${textColor}`}
+        } ${textColor} ${forceGray ? 'filter grayscale' : ''}`}
       >
         <div
           className={`mx-auto flex h-[clamp(3rem,6vw,3.75rem)] w-full items-center pt-3 px-[clamp(1rem,4vw,3rem)] ${textColor}`}

--- a/src/components/homepage/Hero.tsx
+++ b/src/components/homepage/Hero.tsx
@@ -374,14 +374,18 @@ export function HeroContent({
   );
 };
 
-export default function HeroSection(props: HeroProps) {
+export default function HeroSection({ reveal: revealProp, ...props }: HeroProps & { reveal?: boolean }) {
   const [reveal, setReveal] = useState(false);
   const overlaySegments = parseTaggedText(props.headline);
 
   useEffect(() => {
+    if (revealProp !== undefined) {
+      setReveal(revealProp);
+      return;
+    }
     const timeout = setTimeout(() => setReveal(true), 1600);
     return () => clearTimeout(timeout);
-  }, []);
+  }, [revealProp]);
 
   return (
     <div className="relative w-full overflow-hidden">
@@ -398,12 +402,14 @@ export default function HeroSection(props: HeroProps) {
             <div className="mb-6 text-[clamp(0.85rem,1.2vw,0.9rem)] font-thin tracking-widest text-charcoal invisible">
               HELLO, WE ARE NPR MEDIA
             </div>
-            <h1 className="mb-6 w-full text-blood text-[clamp(2.5rem,6vw,4.5rem)] leading-[1.1] font-grotesk font-bold tracking-tight">
+            <h1 className="mb-6 w-full text-charcoal/30 text-[clamp(2.5rem,6vw,4.5rem)] leading-[1.1] font-grotesk font-bold tracking-tight">
               {overlaySegments.map((seg, i) => (
                 <span
                   key={i}
                   className={clsx(
-                    seg.text.trim() === 'Trusted by' ? 'text-blood' : 'text-transparent'
+                    seg.text.trim() === 'Trusted by'
+                      ? 'text-blood'
+                      : 'text-charcoal/50'
                   )}
                 >
                   {seg.text}


### PR DESCRIPTION
## Summary
- sync hero reveal state at page level
- add grayscale toggle to header
- fade non-highlight hero words

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_687d5c19092c8328875cf00a3eacf408