### PR TITLE
Add Stat Impact section

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,7 @@ import StickyHeader from '@/components/global/Header';
 import HeroSection from '@/components/homepage/Hero';
 import { hero } from '@/content/homepage/hero';
 import IndustryTemplatesSection from '@/components/homepage/IndustryTemplates';
+import StatImpact from '@/components/homepage/StatImpact';
 import PricingSection from '@/components/homepage/PricingSection';
 import FooterSection from '@/components/global/Footer';
 import ContactSection from '@/components/homepage/ContactSection';
@@ -34,6 +35,7 @@ export default function Page() {
           <HeroSection {...hero} reveal={reveal} />
         </Suspense>
         <IndustryTemplatesSection />
+        <StatImpact />
         <PricingSection />
         <ContactSection />
       </main>

--- a/src/components/homepage/StatImpact.tsx
+++ b/src/components/homepage/StatImpact.tsx
@@ -41,16 +41,16 @@ export default function StatImpact() {
         <div className="grid grid-cols-1 gap-x-10 gap-y-12 sm:grid-cols-2 lg:grid-cols-3">
           {stats.map((stat, i) => (
             <div key={i} className="text-center">
-              <motion.span
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                viewport={{ once: true }}
-                transition={{ duration: 0.6, delay: i * 0.1 }}
-                className="text-blood mr-4 inline-block align-top text-[clamp(3rem,6vw,5rem)] font-bold"
-              >
-                {stat.value}
-              </motion.span>
               <p className="mx-auto mt-2 max-w-sm text-base leading-snug text-charcoal">
+                <motion.span
+                  initial={{ opacity: 0, y: 20 }}
+                  whileInView={{ opacity: 1, y: 0 }}
+                  viewport={{ once: true }}
+                  transition={{ duration: 0.6, delay: i * 0.1 }}
+                  className="mr-4 inline-block align-top text-[clamp(3rem,6vw,5rem)] font-bold text-blood"
+                >
+                  {stat.value}
+                </motion.span>
                 {stat.text}
               </p>
               <Link

--- a/src/components/homepage/StatImpact.tsx
+++ b/src/components/homepage/StatImpact.tsx
@@ -41,7 +41,7 @@ export default function StatImpact() {
         <div className="grid grid-cols-1 gap-x-10 gap-y-12 sm:grid-cols-2 lg:grid-cols-3">
           {stats.map((stat, i) => (
             <div key={i} className="text-center">
-              <p className="mx-auto mt-2 max-w-sm text-base leading-snug text-charcoal">
+              <div className="mx-auto mt-2 flex max-w-sm items-start justify-center">
                 <motion.span
                   initial={{ opacity: 0, y: 20 }}
                   whileInView={{ opacity: 1, y: 0 }}
@@ -51,8 +51,8 @@ export default function StatImpact() {
                 >
                   {stat.value}
                 </motion.span>
-                {stat.text}
-              </p>
+                <p className="text-base leading-snug text-charcoal">{stat.text}</p>
+              </div>
               <Link
                 href={stat.href}
                 target="_blank"

--- a/src/components/homepage/StatImpact.tsx
+++ b/src/components/homepage/StatImpact.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import { motion } from 'framer-motion'
+import Link from 'next/link'
+
+interface StatItem {
+  value: string
+  text: string
+  source: string
+  href: string
+}
+
+const stats: StatItem[] = [
+  {
+    value: '182%',
+    text: 'more revenue within 3 months after an ecommerce redesign.',
+    source: 'seoplus.com',
+    href: 'https://seoplus.com/case-studies/redesigned-ecommerce-site-more-revenue',
+  },
+  {
+    value: '81%',
+    text: 'more SaaS signups from a homepage conversion overhaul.',
+    source: 'conversionrate.store',
+    href: 'https://conversionrate.store/case-studies/localizer',
+  },
+  {
+    value: '137%',
+    text: 'jump in SaaS signups after simplifying a landing page.',
+    source: 'reddit.com',
+    href: 'https://www.reddit.com/r/SaaS/comments/1imj02n/redesigned_my_landing_page_and_got_137_more',
+  },
+]
+
+export default function StatImpact() {
+  return (
+    <section className="mt-[clamp(4rem,8vw,8rem)] bg-white px-6 md:px-12">
+      <div className="mx-auto max-w-screen-xl">
+        <h2 className="mb-8 text-center text-[clamp(1.5rem,4vw,2.5rem)] font-bold text-charcoal tracking-tight">
+          Why Founders Invest in a Better Website
+        </h2>
+        <div className="grid grid-cols-1 gap-x-10 gap-y-12 sm:grid-cols-2 lg:grid-cols-3">
+          {stats.map((stat, i) => (
+            <div key={i} className="text-center">
+              <motion.span
+                initial={{ opacity: 0, y: 20 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true }}
+                transition={{ duration: 0.6, delay: i * 0.1 }}
+                className="text-blood mr-4 inline-block align-top text-[clamp(3rem,6vw,5rem)] font-bold"
+              >
+                {stat.value}
+              </motion.span>
+              <p className="mx-auto mt-2 max-w-sm text-base leading-snug text-charcoal">
+                {stat.text}
+              </p>
+              <Link
+                href={stat.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-2 inline-block text-sm text-silver hover:underline"
+              >
+                Source: {stat.source}
+              </Link>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/homepage/StatImpact.tsx
+++ b/src/components/homepage/StatImpact.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from 'framer-motion'
 import Link from 'next/link'
+import CTAButton from '@/components/CTAButton'
 
 interface StatItem {
   value: string
@@ -34,33 +35,41 @@ const stats: StatItem[] = [
 export default function StatImpact() {
   return (
     <section className="mt-[clamp(4rem,8vw,8rem)] bg-white px-6 md:px-12">
-      <div className="mx-auto max-w-screen-xl">
-        <h2 className="mb-8 text-center text-[clamp(1.5rem,4vw,2.5rem)] font-bold text-charcoal tracking-tight">
-          Why Founders Invest in a Better Website
-        </h2>
-        <div className="grid grid-cols-1 gap-x-10 gap-y-12 sm:grid-cols-2 lg:grid-cols-3">
+      <div className="mx-auto grid max-w-screen-xl gap-12 lg:grid-cols-2 lg:items-center">
+        <div className="space-y-4 text-center lg:text-left">
+          <h2 className="text-[clamp(1.5rem,4vw,2.5rem)] font-bold tracking-tight text-charcoal">
+            Why Founders Invest in a Better Website
+          </h2>
+          <p className="mx-auto max-w-md text-base text-charcoal lg:mx-0">
+            Real businesses see dramatic growth after modernizing their online presence.
+          </p>
+          <CTAButton href="/contact" event="cta-stats">
+            Get a Site Review
+          </CTAButton>
+        </div>
+        <div className="space-y-8">
           {stats.map((stat, i) => (
-            <div key={i} className="text-center">
-              <div className="mx-auto mt-2 flex max-w-sm items-start justify-center">
-                <motion.span
-                  initial={{ opacity: 0, y: 20 }}
-                  whileInView={{ opacity: 1, y: 0 }}
-                  viewport={{ once: true }}
-                  transition={{ duration: 0.6, delay: i * 0.1 }}
-                  className="mr-4 inline-block align-top text-[clamp(3rem,6vw,5rem)] font-bold text-blood"
-                >
-                  {stat.value}
-                </motion.span>
-                <p className="text-base leading-snug text-charcoal">{stat.text}</p>
-              </div>
-              <Link
-                href={stat.href}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="mt-2 inline-block text-sm text-silver hover:underline"
+            <div key={i} className="flex items-start">
+              <motion.span
+                initial={{ opacity: 0, y: 20 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true }}
+                transition={{ duration: 0.6, delay: i * 0.1 }}
+                className="mr-4 inline-block align-top text-[clamp(3rem,6vw,5rem)] font-bold text-blood"
               >
-                Source: {stat.source}
-              </Link>
+                {stat.value}
+              </motion.span>
+              <div>
+                <p className="text-base leading-snug text-charcoal">{stat.text}</p>
+                <Link
+                  href={stat.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="mt-2 inline-block text-sm text-silver hover:underline"
+                >
+                  Source: {stat.source}
+                </Link>
+              </div>
             </div>
           ))}
         </div>

--- a/src/components/homepage/StatImpact.tsx
+++ b/src/components/homepage/StatImpact.tsx
@@ -34,7 +34,7 @@ const stats: StatItem[] = [
 
 export default function StatImpact() {
   return (
-    <section className="mt-[clamp(4rem,8vw,8rem)] bg-white px-6 md:px-12">
+    <section className="mt-[clamp(4rem,8vw,8rem)] bg-white px-6 md:px-12 font-grotesk">
       <div className="mx-auto grid max-w-screen-xl gap-12 lg:grid-cols-2 lg:items-center">
         <div className="space-y-4 text-center lg:text-left">
           <h2 className="text-[clamp(1.5rem,4vw,2.5rem)] font-bold tracking-tight text-charcoal">
@@ -55,7 +55,7 @@ export default function StatImpact() {
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
                 transition={{ duration: 0.6, delay: i * 0.1 }}
-                className="mr-4 inline-block align-top text-[clamp(3rem,6vw,5rem)] font-bold text-blood"
+                className="mr-4 inline-block w-[5ch] text-right align-top font-bold text-blood text-[clamp(3rem,6vw,5rem)] font-mono"
               >
                 {stat.value}
               </motion.span>


### PR DESCRIPTION
## Summary
- add StatImpact component to showcase ROI proof
- place StatImpact beneath the demo templates section on the homepage

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_687d6258373c8328bc8ee6e3dc2224b1