### PR TITLE
Update stats section styling

### DIFF
--- a/src/components/homepage/StatImpact.tsx
+++ b/src/components/homepage/StatImpact.tsx
@@ -2,7 +2,7 @@
 
 import { motion } from 'framer-motion'
 import Link from 'next/link'
-import CTAButton from '@/components/CTAButton'
+
 
 interface StatItem {
   value: string
@@ -34,43 +34,47 @@ const stats: StatItem[] = [
 
 export default function StatImpact() {
   return (
-    <section className="mt-[clamp(4rem,8vw,8rem)] bg-white px-6 md:px-12 font-grotesk">
-      <div className="mx-auto grid max-w-screen-xl gap-12 lg:grid-cols-2 lg:items-center">
-        <div className="space-y-4 text-center lg:text-left">
-          <h2 className="text-[clamp(1.5rem,4vw,2.5rem)] font-bold tracking-tight text-charcoal">
+    <section className="mt-[clamp(4rem,8vw,8rem)] bg-white font-grotesk">
+      <div className="max-w-screen-xl mx-auto px-6 md:px-12">
+        <div className="text-center">
+          <h2 className="text-[clamp(2rem,4vw,3rem)] font-black tracking-tight text-charcoal text-center">
             Why Founders Invest in a Better Website
           </h2>
-          <p className="mx-auto max-w-md text-base text-charcoal lg:mx-0">
+          <p className="text-muted text-lg text-center max-w-2xl mx-auto mt-2">
             Real businesses see dramatic growth after modernizing their online presence.
           </p>
-          <CTAButton href="/contact" event="cta-stats">
+          <Link
+            href="/contact"
+            data-event="cta-stats"
+            className="bg-blood text-white px-5 py-3 rounded-xl shadow-lg hover:scale-105 transition-transform font-semibold text-sm tracking-wide mt-6 mx-auto block"
+          >
             Get a Site Review
-          </CTAButton>
+          </Link>
         </div>
-        <div className="space-y-8">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-10 mt-12 text-left relative rounded-2xl shadow-md before:absolute before:inset-0 before:-z-10 before:bg-gradient-to-br before:from-crimson/5 before:to-white before:blur-2xl">
           {stats.map((stat, i) => (
-            <div key={i} className="flex items-start">
-              <motion.span
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                viewport={{ once: true }}
-                transition={{ duration: 0.6, delay: i * 0.1 }}
-                className="mr-4 inline-block w-[5ch] text-right align-top font-bold text-blood text-[clamp(3rem,6vw,5rem)] font-mono"
+            <motion.div
+              key={i}
+              initial={{ opacity: 0, y: 30 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ duration: 0.6, delay: i * 0.1 }}
+            >
+              <p className="text-charcoal text-base leading-snug">
+                <span className="text-[clamp(3rem,6vw,5rem)] font-extrabold text-blood bg-gradient-to-br from-blood/10 to-transparent rounded-xl px-3 py-2 float-left leading-none drop-shadow-md mr-4">
+                  {stat.value}
+                </span>
+                {stat.text}
+              </p>
+              <Link
+                href={stat.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-sm text-zinc-500 italic mt-2 inline-block"
               >
-                {stat.value}
-              </motion.span>
-              <div>
-                <p className="text-base leading-snug text-charcoal">{stat.text}</p>
-                <Link
-                  href={stat.href}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="mt-2 inline-block text-sm text-silver hover:underline"
-                >
-                  Source: {stat.source}
-                </Link>
-              </div>
-            </div>
+                Source: {stat.source}
+              </Link>
+            </motion.div>
           ))}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- modernize StatImpact section with improved layout and framer motion effects
- use drop-cap style numbers and new CTA button

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_687d78dae47883289a0b660dd274ac42