### PR TITLE
Refine stats section design

### DIFF
--- a/src/components/homepage/StatImpact.tsx
+++ b/src/components/homepage/StatImpact.tsx
@@ -34,45 +34,50 @@ const stats: StatItem[] = [
 
 export default function StatImpact() {
   return (
-    <section className="mt-[clamp(4rem,8vw,8rem)] bg-white px-6 md:px-12 font-grotesk">
-      <div className="mx-auto grid max-w-screen-xl gap-12 lg:grid-cols-2 lg:items-center">
-        <div className="space-y-4 text-center lg:text-left">
-          <h2 className="text-[clamp(1.5rem,4vw,2.5rem)] font-bold tracking-tight text-charcoal">
+    <section className="mt-[clamp(4rem,8vw,8rem)] font-grotesk">
+      <div className="max-w-screen-md mx-auto px-6 md:px-8">
+        <div className="text-center">
+          <h2 className="text-[clamp(2rem,4vw,3rem)] font-black tracking-tight text-charcoal">
             Why Founders Invest in a Better Website
           </h2>
-          <p className="mx-auto max-w-md text-base text-charcoal lg:mx-0">
+          <p className="text-silver text-lg text-center mt-2">
             Real businesses see dramatic growth after modernizing their online presence.
           </p>
-          <CTAButton href="/contact" event="cta-stats">
-            Get a Site Review
-          </CTAButton>
         </div>
-        <div className="space-y-8">
+        <div className="mt-8 space-y-0">
           {stats.map((stat, i) => (
-            <div key={i} className="flex items-start">
-              <motion.span
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                viewport={{ once: true }}
-                transition={{ duration: 0.6, delay: i * 0.1 }}
-                className="mr-4 inline-block w-[5ch] text-right align-top font-bold text-blood text-[clamp(3rem,6vw,5rem)] font-mono"
-              >
+            <motion.div
+              key={i}
+              initial={{ opacity: 0, y: 30 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ duration: 0.5, delay: i * 0.2 }}
+              className="flex items-start gap-4 py-6 border-t border-silver/30 last:border-b bg-white/60 rounded-xl shadow-sm hover:shadow-md transition-shadow duration-300"
+            >
+              <span className="text-[clamp(3rem,6vw,5rem)] font-extrabold text-blood bg-gradient-to-br from-blood/10 to-transparent px-3 py-1 rounded-xl drop-shadow-md shrink-0 transition-transform hover:scale-105">
                 {stat.value}
-              </motion.span>
-              <div>
-                <p className="text-base leading-snug text-charcoal">{stat.text}</p>
+              </span>
+              <div className="flex-1">
+                <p className="text-base text-charcoal leading-snug">{stat.text}</p>
                 <Link
                   href={stat.href}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="mt-2 inline-block text-sm text-silver hover:underline"
+                  className="text-sm text-zinc-500 italic mt-1"
                 >
                   Source: {stat.source}
                 </Link>
               </div>
-            </div>
+            </motion.div>
           ))}
         </div>
+        <CTAButton
+          href="/contact"
+          event="cta-stats"
+          className="bg-blood text-white px-5 py-3 rounded-xl shadow-lg hover:scale-105 transition-transform font-semibold text-sm tracking-wide mt-8 mx-auto block"
+        >
+          Get a Site Review
+        </CTAButton>
       </div>
     </section>
   )

--- a/src/components/homepage/StatImpact.tsx
+++ b/src/components/homepage/StatImpact.tsx
@@ -35,16 +35,23 @@ const stats: StatItem[] = [
 export default function StatImpact() {
   return (
     <section className="mt-[clamp(4rem,8vw,8rem)] font-grotesk">
-      <div className="max-w-screen-md mx-auto px-6 md:px-8">
-        <div className="text-center">
+      <div className="max-w-screen-md mx-auto grid gap-10 px-6 md:px-8 lg:grid-cols-2 lg:items-start">
+        <div className="space-y-4 text-center lg:text-left">
           <h2 className="text-[clamp(2rem,4vw,3rem)] font-black tracking-tight text-charcoal">
             Why Founders Invest in a Better Website
           </h2>
-          <p className="text-silver text-lg text-center mt-2">
+          <p className="text-silver text-lg mt-2">
             Real businesses see dramatic growth after modernizing their online presence.
           </p>
+          <CTAButton
+            href="/contact"
+            event="cta-stats"
+            className="bg-blood text-white px-5 py-3 rounded-xl shadow-lg hover:scale-105 transition-transform font-semibold text-sm tracking-wide block w-max"
+          >
+            Get a Site Review
+          </CTAButton>
         </div>
-        <div className="mt-8 space-y-0">
+        <div className="space-y-0 mt-8 lg:mt-0">
           {stats.map((stat, i) => (
             <motion.div
               key={i}
@@ -71,13 +78,6 @@ export default function StatImpact() {
             </motion.div>
           ))}
         </div>
-        <CTAButton
-          href="/contact"
-          event="cta-stats"
-          className="bg-blood text-white px-5 py-3 rounded-xl shadow-lg hover:scale-105 transition-transform font-semibold text-sm tracking-wide mt-8 mx-auto block"
-        >
-          Get a Site Review
-        </CTAButton>
       </div>
     </section>
   )


### PR DESCRIPTION
## Summary
- redesign the StatImpact section for a more polished vertical layout
- animate each stat block with Framer Motion
- enhance call to action styling

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_687d7c189b2c8328ad96cf15488eb6d2