### PR TITLE
Fix layout of 'How NPR Media Delivers' section

### DIFF
--- a/src/app/why-npr/page.tsx
+++ b/src/app/why-npr/page.tsx
@@ -95,8 +95,8 @@ export default function WhyNprPage() {
                   className="mx-auto mt-2 text-blood"
                 />
               </div>
-              <div id="npr-delivers" className="md:grid md:grid-cols-2 md:items-center md:gap-8">
-                <div className="ml-20 space-y-2 pb-8 text-center md:pb-0 md:text-left">
+              <div id="npr-delivers" className="grid grid-cols-12 items-center gap-x-6">
+                <div className="col-span-12 lg:col-span-6 space-y-2 pb-8 text-center lg:pb-0 lg:text-right lg:pr-8">
                   <h2 className="mb-3 text-3xl text-olive underline decoration-2 underline-offset-3 font-extrabold sm:text-4xl">How NPR Media Delivers</h2>
                   <p className="text-sm text-charcoal">
                     Hands-on strategy that actually moves the needle
@@ -112,6 +112,7 @@ export default function WhyNprPage() {
                   </div>
                 </div>
                 <motion.div
+                  className="col-span-12 lg:col-span-6 lg:pl-8"
                   initial={{ opacity: 0, y: 40 }}
                   whileInView={{ opacity: 1, y: 0 }}
                   viewport={{ once: true }}

--- a/src/components/whyNpr/NprCarousel.tsx
+++ b/src/components/whyNpr/NprCarousel.tsx
@@ -80,7 +80,7 @@ export default function NprCarousel() {
         ))}
       </div>
       <ChevronRight
-        className="pointer-events-none absolute right-2 top-1/2 h-8 w-8 -translate-y-1/2 animate-bounce text-blood"
+        className="pointer-events-none absolute right-4 lg:right-6 top-1/2 h-8 w-8 -translate-y-1/2 animate-bounce text-blood"
       />
     </div>
   )

--- a/src/components/whyNpr/NprCarousel.tsx
+++ b/src/components/whyNpr/NprCarousel.tsx
@@ -47,7 +47,7 @@ export default function NprCarousel() {
   }, [index])
 
   return (
-    <div className="relative h-screen overflow-hidden">
+    <div className="relative mx-auto h-screen w-[clamp(16rem,40vw,22rem)] overflow-hidden">
       <div
         ref={containerRef}
         className="flex h-full snap-x snap-mandatory overflow-x-scroll scroll-smooth no-scrollbar"


### PR DESCRIPTION
## Summary
- improve carousel arrow placement in `NprCarousel`
- refactor `How NPR Media Delivers` layout using a responsive 12-column grid

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68828e47bca883289e480f794e658843