### PR TITLE
Fix carousel layout alignment

### DIFF
--- a/src/app/why-npr/page.tsx
+++ b/src/app/why-npr/page.tsx
@@ -95,7 +95,7 @@ export default function WhyNprPage() {
                   className="mx-auto mt-2 text-blood"
                 />
               </div>
-              <div id="npr-delivers" className="md:grid md:grid-cols-2 md:items-center md:gap-8">
+              <div id="npr-delivers" className="md:grid md:grid-cols-2 md:items-center md:gap-8 overflow-hidden">
                 <div className="ml-20 space-y-2 pb-8 text-center md:pb-0 md:text-left">
                   <h2 className="mb-3 text-3xl text-olive underline decoration-2 underline-offset-3 font-extrabold sm:text-4xl">How NPR Media Delivers</h2>
                   <p className="text-sm text-charcoal">

--- a/src/components/whyNpr/NprCarousel.tsx
+++ b/src/components/whyNpr/NprCarousel.tsx
@@ -47,15 +47,15 @@ export default function NprCarousel() {
   }, [index])
 
   return (
-    <div className="relative h-screen overflow-hidden">
+    <div className="relative h-screen w-full overflow-hidden">
       <div
         ref={containerRef}
-        className="flex h-full snap-x snap-mandatory overflow-x-scroll scroll-smooth no-scrollbar"
+        className="flex h-full w-full snap-x snap-mandatory overflow-x-scroll scroll-smooth no-scrollbar"
       >
         {slides.map((title) => (
           <section
             key={title}
-            className="flex min-h-screen min-w-full items-center justify-center snap-center"
+            className="flex h-full w-full flex-shrink-0 items-center justify-center snap-center"
           >
             <AnimatePresence mode="wait" initial={false}>
               {index === slides.indexOf(title) && (
@@ -80,7 +80,7 @@ export default function NprCarousel() {
         ))}
       </div>
       <ChevronRight
-        className="pointer-events-none absolute right-2 top-1/2 h-8 w-8 -translate-y-1/2 animate-bounce text-blood"
+        className="pointer-events-none absolute right-4 lg:right-6 top-1/2 h-8 w-8 -translate-y-1/2 animate-bounce text-blood"
       />
     </div>
   )

--- a/src/components/whyNpr/NprCarousel.tsx
+++ b/src/components/whyNpr/NprCarousel.tsx
@@ -47,7 +47,7 @@ export default function NprCarousel() {
   }, [index])
 
   return (
-    <div className="relative h-screen w-full overflow-hidden">
+    <div className="relative h-screen w-full overflow-hidden ml-20">
       <div
         ref={containerRef}
         className="flex h-full w-full snap-x snap-mandatory overflow-x-scroll scroll-smooth no-scrollbar"
@@ -55,7 +55,7 @@ export default function NprCarousel() {
         {slides.map((title) => (
           <section
             key={title}
-            className="flex h-full w-full flex-shrink-0 items-center justify-center snap-center"
+            className="flex h-full w-full flex-shrink-0 items-center justify-start snap-center"
           >
             <AnimatePresence mode="wait" initial={false}>
               {index === slides.indexOf(title) && (


### PR DESCRIPTION
## Summary
- keep NPR carousel width within grid columns
- add overflow-hidden to container to clamp card track
- place next-arrow closer to cards

## Testing
- `pnpm lint`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_6882b2fa8fdc83288d86c6341a3b3137