### PR TITLE
Change hero reveal direction

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -291,12 +291,12 @@ img {
 /* Utilities for the hero reveal effect */
 .clip-reveal-hidden {
   /* Start collapsed on the left side */
-  clip-path: polygon(0 0, 0 0, 0 100%, 0 100%);
+  clip-path: inset(0 100% 0 0);
 }
 
 .clip-reveal-full {
   /* Expand horizontally to reveal the full section */
-  clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
+  clip-path: inset(0 0 0 0);
 }
 
 @keyframes glow-pulse {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -290,11 +290,13 @@ img {
 
 /* Utilities for the hero reveal effect */
 .clip-reveal-hidden {
-  clip-path: polygon(0 100%, 0 100%, 0 100%, 0 100%);
+  /* Start collapsed on the left side */
+  clip-path: polygon(0 0, 0 0, 0 100%, 0 100%);
 }
 
 .clip-reveal-full {
-  clip-path: polygon(0 100%, 100% 100%, 100% 0, 0 0);
+  /* Expand horizontally to reveal the full section */
+  clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
 }
 
 @keyframes glow-pulse {


### PR DESCRIPTION
## Summary
- tweak `.clip-reveal-hidden` and `.clip-reveal-full` to start on the left and slide right

## Testing
- `pnpm lint`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68842e16025883288f8023eb10c56ddb