### PR TITLE
Add blood gradient and grayscale reveal

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -4,9 +4,12 @@
   --font-sans: ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
     'Noto Color Emoji';
   --color-gray-400: oklch(70.7% 0.022 261.325);
+  --color-zinc-500: oklch(55.2% 0.016 285.938);
   --color-black: #000;
   --color-white: #fff;
   --spacing: 0.25rem;
+  --breakpoint-md: 48rem;
+  --breakpoint-xl: 80rem;
   --container-md: 28rem;
   --container-xl: 36rem;
   --container-2xl: 42rem;
@@ -18,6 +21,8 @@
   --text-xs--line-height: calc(1 / 0.75);
   --text-sm: 0.875rem;
   --text-sm--line-height: calc(1.25 / 0.875);
+  --text-base: 1rem;
+  --text-base--line-height: calc(1.5 / 1);
   --text-lg: 1.125rem;
   --text-lg--line-height: calc(1.75 / 1.125);
   --text-xl: 1.25rem;
@@ -36,6 +41,7 @@
   --font-weight-semibold: 600;
   --font-weight-bold: 700;
   --font-weight-extrabold: 800;
+  --font-weight-black: 900;
   --tracking-tight: -0.025em;
   --tracking-wide: 0.025em;
   --tracking-wider: 0.05em;
@@ -46,6 +52,7 @@
   --radius-lg: 0.5rem;
   --radius-xl: 0.75rem;
   --radius-2xl: 1rem;
+  --ease-out: cubic-bezier(0, 0, 0.2, 1);
   --ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
   --animate-spin: spin 1s linear infinite;
   --animate-bounce: bounce 1s infinite;
@@ -173,6 +180,12 @@
 .z-\[3\] {
   z-index: 3;
 }
+.z-\[60\] {
+  z-index: 60;
+}
+.z-\[70\] {
+  z-index: 70;
+}
 .container {
   width: 100%;
   @media (width >= 40rem) {
@@ -200,6 +213,9 @@
 .my-16 {
   margin-block: calc(var(--spacing) * 16);
 }
+.mt-0\.5 {
+  margin-top: calc(var(--spacing) * 0.5);
+}
 .mt-1 {
   margin-top: calc(var(--spacing) * 1);
 }
@@ -215,14 +231,14 @@
 .mt-8 {
   margin-top: calc(var(--spacing) * 8);
 }
-.mt-10 {
-  margin-top: calc(var(--spacing) * 10);
-}
 .mt-12 {
   margin-top: calc(var(--spacing) * 12);
 }
 .mt-16 {
   margin-top: calc(var(--spacing) * 16);
+}
+.mt-\[clamp\(2rem\,4vw\,4rem\)\] {
+  margin-top: clamp(2rem, 4vw, 4rem);
 }
 .mt-auto {
   margin-top: auto;
@@ -259,6 +275,9 @@
 }
 .ml-4 {
   margin-left: calc(var(--spacing) * 4);
+}
+.ml-20 {
+  margin-left: calc(var(--spacing) * 20);
 }
 .ml-\[calc\(50vw-1rem\)\] {
   margin-left: calc(50vw - 1rem);
@@ -426,6 +445,9 @@
 .max-w-7xl {
   max-width: var(--container-7xl);
 }
+.max-w-\[36ch\] {
+  max-width: 36ch;
+}
 .max-w-\[60ch\] {
   max-width: 60ch;
 }
@@ -441,11 +463,17 @@
 .max-w-md {
   max-width: var(--container-md);
 }
+.max-w-prose {
+  max-width: 65ch;
+}
+.max-w-screen-md {
+  max-width: var(--breakpoint-md);
+}
+.max-w-screen-xl {
+  max-width: var(--breakpoint-xl);
+}
 .max-w-xl {
   max-width: var(--container-xl);
-}
-.min-w-full {
-  min-width: 100%;
 }
 .flex-1 {
   flex: 1;
@@ -491,9 +519,6 @@
 }
 .resize-none {
   resize: none;
-}
-.snap-x {
-  scroll-snap-type: x var(--tw-scroll-snap-strictness);
 }
 .snap-y {
   scroll-snap-type: y var(--tw-scroll-snap-strictness);
@@ -618,13 +643,6 @@
     margin-block-end: calc(calc(var(--spacing) * 12) * calc(1 - var(--tw-space-y-reverse)));
   }
 }
-.space-y-24 {
-  :where(& > :not(:last-child)) {
-    --tw-space-y-reverse: 0;
-    margin-block-start: calc(calc(var(--spacing) * 24) * var(--tw-space-y-reverse));
-    margin-block-end: calc(calc(var(--spacing) * 24) * calc(1 - var(--tw-space-y-reverse)));
-  }
-}
 .gap-x-6 {
   -moz-column-gap: calc(var(--spacing) * 6);
        column-gap: calc(var(--spacing) * 6);
@@ -639,9 +657,6 @@
 }
 .overflow-x-hidden {
   overflow-x: hidden;
-}
-.overflow-x-scroll {
-  overflow-x: scroll;
 }
 .overflow-y-scroll {
   overflow-y: scroll;
@@ -699,6 +714,12 @@
 }
 .bg-transparent {
   background-color: transparent;
+}
+.bg-white\/60 {
+  background-color: color-mix(in srgb, #fff 60%, transparent);
+  @supports (color: color-mix(in lab, red, red)) {
+    background-color: color-mix(in oklab, var(--color-white) 60%, transparent);
+  }
 }
 .bg-gradient-to-b {
   --tw-gradient-position: to bottom in oklab;
@@ -789,11 +810,20 @@
 .p-6 {
   padding: calc(var(--spacing) * 6);
 }
+.p-8 {
+  padding: calc(var(--spacing) * 8);
+}
+.p-10 {
+  padding: calc(var(--spacing) * 10);
+}
 .px-0 {
   padding-inline: calc(var(--spacing) * 0);
 }
 .px-2 {
   padding-inline: calc(var(--spacing) * 2);
+}
+.px-3 {
+  padding-inline: calc(var(--spacing) * 3);
 }
 .px-4 {
   padding-inline: calc(var(--spacing) * 4);
@@ -810,11 +840,11 @@
 .px-\[clamp\(0\.75rem\,2vw\,1rem\)\] {
   padding-inline: clamp(0.75rem, 2vw, 1rem);
 }
+.px-\[clamp\(0\.875rem\,2\.75vw\,1\.5rem\)\] {
+  padding-inline: clamp(0.875rem, 2.75vw, 1.5rem);
+}
 .px-\[clamp\(1\.25rem\,3vw\,1\.5rem\)\] {
   padding-inline: clamp(1.25rem, 3vw, 1.5rem);
-}
-.px-\[clamp\(1\.875rem\,3\.75vw\,2\.5rem\)\] {
-  padding-inline: clamp(1.875rem, 3.75vw, 2.5rem);
 }
 .px-\[clamp\(1rem\,2\.5vw\,1\.5rem\)\] {
   padding-inline: clamp(1rem, 2.5vw, 1.5rem);
@@ -827,6 +857,9 @@
 }
 .px-\[clamp\(1rem\,4vw\,3rem\)\] {
   padding-inline: clamp(1rem, 4vw, 3rem);
+}
+.py-0\.5 {
+  padding-block: calc(var(--spacing) * 0.5);
 }
 .py-1 {
   padding-block: calc(var(--spacing) * 1);
@@ -843,6 +876,9 @@
 .py-5 {
   padding-block: calc(var(--spacing) * 5);
 }
+.py-6 {
+  padding-block: calc(var(--spacing) * 6);
+}
 .py-12 {
   padding-block: calc(var(--spacing) * 12);
 }
@@ -852,6 +888,9 @@
 .py-24 {
   padding-block: calc(var(--spacing) * 24);
 }
+.py-\[clamp\(0\.4rem\,1vw\,\.75rem\)\] {
+  padding-block: clamp(0.4rem, 1vw, .75rem);
+}
 .py-\[clamp\(0\.4rem\,1vw\,0\.6rem\)\] {
   padding-block: clamp(0.4rem, 1vw, 0.6rem);
 }
@@ -860,9 +899,6 @@
 }
 .py-\[clamp\(0\.6rem\,1\.2vw\,0\.75rem\)\] {
   padding-block: clamp(0.6rem, 1.2vw, 0.75rem);
-}
-.py-\[clamp\(0\.9rem\,1\.5vw\,1\.25rem\)\] {
-  padding-block: clamp(0.9rem, 1.5vw, 1.25rem);
 }
 .py-\[clamp\(2\.5rem\,6vw\,4rem\)\] {
   padding-block: clamp(2.5rem, 6vw, 4rem);
@@ -897,6 +933,9 @@
 .pt-16 {
   padding-top: calc(var(--spacing) * 16);
 }
+.pt-20 {
+  padding-top: calc(var(--spacing) * 20);
+}
 .pt-\[clamp\(1rem\,5vw\,3rem\)\] {
   padding-top: clamp(1rem, 5vw, 3rem);
 }
@@ -911,6 +950,9 @@
 }
 .pb-\[5vh\] {
   padding-bottom: 5vh;
+}
+.pb-\[clamp\(2rem\,4vw\,4rem\)\] {
+  padding-bottom: clamp(2rem, 4vw, 4rem);
 }
 .pb-\[clamp\(4rem\,8vw\,6rem\)\] {
   padding-bottom: clamp(4rem, 8vw, 6rem);
@@ -941,6 +983,10 @@
 .text-4xl {
   font-size: var(--text-4xl);
   line-height: var(--tw-leading, var(--text-4xl--line-height));
+}
+.text-base {
+  font-size: var(--text-base);
+  line-height: var(--tw-leading, var(--text-base--line-height));
 }
 .text-lg {
   font-size: var(--text-lg);
@@ -1047,6 +1093,10 @@
   --tw-leading: var(--leading-snug);
   line-height: var(--leading-snug);
 }
+.font-black {
+  --tw-font-weight: var(--font-weight-black);
+  font-weight: var(--font-weight-black);
+}
 .font-bold {
   --tw-font-weight: var(--font-weight-bold);
   font-weight: var(--font-weight-bold);
@@ -1091,11 +1141,23 @@
   --tw-tracking: var(--tracking-widest);
   letter-spacing: var(--tracking-widest);
 }
+.break-words {
+  overflow-wrap: break-word;
+}
 .text-gray-400 {
   color: var(--color-gray-400);
 }
-.text-transparent {
-  color: transparent;
+.text-white {
+  color: var(--color-white);
+}
+.text-white\/90 {
+  color: color-mix(in srgb, #fff 90%, transparent);
+  @supports (color: color-mix(in lab, red, red)) {
+    color: color-mix(in oklab, var(--color-white) 90%, transparent);
+  }
+}
+.text-zinc-500 {
+  color: var(--color-zinc-500);
 }
 .uppercase {
   text-transform: uppercase;
@@ -1106,20 +1168,27 @@
 .underline {
   text-decoration-line: underline;
 }
+.decoration-1 {
+  text-decoration-thickness: 1px;
+}
+.decoration-2 {
+  text-decoration-thickness: 2px;
+}
+.underline-offset-2 {
+  text-underline-offset: 2px;
+}
+.underline-offset-3 {
+  text-underline-offset: 3px;
+}
 .underline-offset-4 {
   text-underline-offset: 4px;
+}
+.underline-offset-5 {
+  text-underline-offset: 5px;
 }
 .antialiased {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-}
-.placeholder-transparent {
-  &::-moz-placeholder {
-    color: transparent;
-  }
-  &::placeholder {
-    color: transparent;
-  }
 }
 .opacity-0 {
   opacity: 0%;
@@ -1151,6 +1220,10 @@
   --tw-shadow: 0 0 20px var(--tw-shadow-color, rgba(179,0,0,0.2));
   box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
 }
+.shadow-\[0_2px_6px_rgba\(28\,28\,28\,0\.06\)\,_0_8px_24px_rgba\(28\,28\,28\,0\.04\)\] {
+  --tw-shadow: 0 2px 6px var(--tw-shadow-color, rgba(28,28,28,0.06)), 0 8px 24px var(--tw-shadow-color, rgba(28,28,28,0.04));
+  box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+}
 .shadow-inner {
   --tw-shadow: inset 0 2px 4px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.05));
   box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
@@ -1161,10 +1234,6 @@
 }
 .shadow-md {
   --tw-shadow: 0 4px 6px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 2px 4px -2px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
-  box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
-}
-.shadow-none {
-  --tw-shadow: 0 0 #0000;
   box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
 }
 .shadow-sm {
@@ -1207,13 +1276,13 @@
 .filter-none {
   filter: none;
 }
-.backdrop-blur {
-  --tw-backdrop-blur: blur(8px);
+.backdrop-blur-md {
+  --tw-backdrop-blur: blur(var(--blur-md));
   -webkit-backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
   backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
 }
-.backdrop-blur-md {
-  --tw-backdrop-blur: blur(var(--blur-md));
+.backdrop-grayscale {
+  --tw-backdrop-grayscale: grayscale(100%);
   -webkit-backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
   backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
 }
@@ -1224,6 +1293,11 @@
 }
 .transition-\[clip-path\] {
   transition-property: clip-path;
+  transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+  transition-duration: var(--tw-duration, var(--default-transition-duration));
+}
+.transition-\[filter\] {
+  transition-property: filter;
   transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
   transition-duration: var(--tw-duration, var(--default-transition-duration));
 }
@@ -1252,6 +1326,9 @@
   transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
   transition-duration: var(--tw-duration, var(--default-transition-duration));
 }
+.transition-none {
+  transition-property: none;
+}
 .duration-200 {
   --tw-duration: 200ms;
   transition-duration: 200ms;
@@ -1268,6 +1345,10 @@
   --tw-duration: 700ms;
   transition-duration: 700ms;
 }
+.duration-\[1000ms\] {
+  --tw-duration: 1000ms;
+  transition-duration: 1000ms;
+}
 .duration-\[2000ms\] {
   --tw-duration: 2000ms;
   transition-duration: 2000ms;
@@ -1275,6 +1356,15 @@
 .ease-in-out {
   --tw-ease: var(--ease-in-out);
   transition-timing-function: var(--ease-in-out);
+}
+.ease-out {
+  --tw-ease: var(--ease-out);
+  transition-timing-function: var(--ease-out);
+}
+.select-none {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+       user-select: none;
 }
 .group-hover\:translate-x-1 {
   &:is(:where(.group):hover *) {
@@ -1303,41 +1393,6 @@
     @media (hover: hover) {
       opacity: 100%;
     }
-  }
-}
-.peer-placeholder-shown\:top-1\/2 {
-  &:is(:where(.peer):-moz-placeholder ~ *) {
-    top: calc(1/2 * 100%);
-  }
-  &:is(:where(.peer):placeholder-shown ~ *) {
-    top: calc(1/2 * 100%);
-  }
-}
-.peer-placeholder-shown\:-translate-y-1\/2 {
-  &:is(:where(.peer):-moz-placeholder ~ *) {
-    --tw-translate-y: calc(calc(1/2 * 100%) * -1);
-    translate: var(--tw-translate-x) var(--tw-translate-y);
-  }
-  &:is(:where(.peer):placeholder-shown ~ *) {
-    --tw-translate-y: calc(calc(1/2 * 100%) * -1);
-    translate: var(--tw-translate-x) var(--tw-translate-y);
-  }
-}
-.peer-focus\:top-2 {
-  &:is(:where(.peer):focus ~ *) {
-    top: calc(var(--spacing) * 2);
-  }
-}
-.peer-focus\:-translate-y-0 {
-  &:is(:where(.peer):focus ~ *) {
-    --tw-translate-y: calc(var(--spacing) * -0);
-    translate: var(--tw-translate-x) var(--tw-translate-y);
-  }
-}
-.peer-focus\:text-xs {
-  &:is(:where(.peer):focus ~ *) {
-    font-size: var(--text-xs);
-    line-height: var(--tw-leading, var(--text-xs--line-height));
   }
 }
 .after\:absolute {
@@ -1451,6 +1506,14 @@
   &:hover {
     @media (hover: hover) {
       --tw-shadow: 0 10px 15px -3px var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 4px 6px -4px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
+      box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+    }
+  }
+}
+.hover\:ring-4 {
+  &:hover {
+    @media (hover: hover) {
+      --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(4px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
       box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
     }
   }
@@ -1622,6 +1685,11 @@
     padding: calc(var(--spacing) * 8);
   }
 }
+.md\:px-5 {
+  @media (width >= 48rem) {
+    padding-inline: calc(var(--spacing) * 5);
+  }
+}
 .md\:px-12 {
   @media (width >= 48rem) {
     padding-inline: calc(var(--spacing) * 12);
@@ -1701,10 +1769,10 @@
   --font-body: 'Inter', sans-serif;
   --font-didot: 'GFS Didot', serif;
   --font-grotesk: 'Space Grotesk', sans-serif;
-  --color-offwhite: #f5f1e8;
-  --color-offwhite-rgb: 245, 241, 232;
-  --color-antique: #d7c7a5;
-  --color-antique-rgb: 215 199 165;
+  --color-offwhite: #FDFCF8;
+  --color-offwhite-rgb: 253 252 248;
+  --color-antique: #FAF4E9;
+  --color-antique-rgb: 250 244 233;
   --color-sepia: #b7a077;
   --color-sepia-rgb: 183 160 119;
   --color-olive: #786c4f;
@@ -1713,12 +1781,16 @@
   --color-umber-rgb: 59 50 36;
   --color-silver: #d2d2d2;
   --color-silver-rgb: 210 210 210;
-  --color-charcoal: #2f2f2f;
-  --color-charcoal-rgb: 47 47 47;
-  --color-blood: #b30000;
-  --color-blood-rgb: 179 0 0;
+  --color-charcoal: #1C1C1C;
+  --color-charcoal-rgb: 28 28 28;
+  --color-blood: #A10204;
+  --color-blood-rgb: 161 2 4;
   --color-crimson: #7a0000;
   --color-crimson-rgb: 122 0 0;
+  --color-muted-text: #4C4C4C;
+  --color-muted-text-rgb: 76 76 76;
+  --color-border-gray: #E4E0D9;
+  --color-border-gray-rgb: 228 224 217;
   --color-bg-primary: var(--color-antique);
   --color-bg-secondary: var(--color-sepia);
   --color-text-dark: var(--color-charcoal);
@@ -1740,6 +1812,17 @@ body {
   padding: 0;
   overflow-x: hidden;
   padding-bottom: env(safe-area-inset-bottom);
+  position: relative;
+}
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  background-image: radial-gradient(rgba(28, 28, 28, 0.05) 1px, transparent 1px);
+  background-size: 3px 3px;
+  opacity: 0.06;
 }
 p {
   overflow-wrap: break-word;
@@ -1841,13 +1924,35 @@ img {
     background-color: rgb(var(--color-blood-rgb));
   }
   .text-blood {
-    color: rgb(var(--color-blood-rgb));
+    background-image: linear-gradient(to bottom, #A10204, #870003);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+  }
+  .text-blood-glow {
+    background-image: linear-gradient(to bottom, #A10204, #870003);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+    text-shadow: 0 1px 4px rgba(161, 2, 4, 0.45);
   }
   .bg-crimson {
     background-color: rgb(var(--color-crimson-rgb));
   }
   .text-crimson {
     color: rgb(var(--color-crimson-rgb));
+  }
+  .text-muted-text {
+    color: rgb(var(--color-muted-text-rgb));
+  }
+  .bg-border-gray {
+    background-color: rgb(var(--color-border-gray-rgb));
+  }
+  .text-border-gray {
+    color: rgb(var(--color-border-gray-rgb));
+  }
+  .border-border-gray {
+    border-color: rgb(var(--color-border-gray-rgb));
   }
   .bg-blood\/20 {
     background-color: rgb(var(--color-blood-rgb) / 0.2);
@@ -2012,10 +2117,10 @@ img {
   }
 }
 .clip-reveal-hidden {
-  clip-path: polygon(0 100%, 0 100%, 0 100%, 0 100%);
+  clip-path: polygon(0 100%, 100% 0, 100% 0, 0 100%);
 }
 .clip-reveal-full {
-  clip-path: polygon(0 100%, 100% 100%, 100% 0, 0 0);
+  clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
 }
 @keyframes glow-pulse {
   0%, 100% {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,22 +15,35 @@ import ContactSection from '@/components/homepage/ContactSection';
 export default function Page() {
   const pathname = usePathname();
   const [reveal, setReveal] = useState(false);
+  const [prefersReduced, setPrefersReduced] = useState(false);
 
   useEffect(() => {
-    const timer = setTimeout(() => setReveal(true), 1600);
-    return () => clearTimeout(timer);
+    setPrefersReduced(window.matchMedia('(prefers-reduced-motion: reduce)').matches);
   }, []);
+
+  useEffect(() => {
+    const delay = prefersReduced ? 0 : 1400;
+    const timer = setTimeout(() => setReveal(true), delay);
+    return () => clearTimeout(timer);
+  }, [prefersReduced]);
 
   return (
     <section>
       <StickyHeader light forceGray={!reveal} />
       <div
         className={clsx(
-          'pointer-events-none fixed inset-0 z-[60] transition-[clip-path] duration-[2000ms] ease-in-out backdrop-grayscale',
+          'pointer-events-none fixed inset-0 z-[60] backdrop-grayscale',
+          prefersReduced ? 'transition-none' : 'transition-[clip-path] duration-[1000ms] ease-in-out',
           reveal ? 'clip-reveal-hidden' : 'clip-reveal-full'
         )}
       />
-      <main key={pathname} className="relative w-full overflow-x-hidden bg-antique text-charcoal">
+      <main
+        key={pathname}
+        className={clsx(
+          'relative w-full overflow-x-hidden bg-antique text-charcoal transition-[filter] duration-500',
+          reveal ? 'filter-none' : 'filter grayscale'
+        )}
+      >
         <Suspense>
           <HeroSection {...hero} reveal={reveal} />
         </Suspense>

--- a/src/components/CTAButton.tsx
+++ b/src/components/CTAButton.tsx
@@ -8,7 +8,13 @@ interface CTAButtonProps {
   className?: string;
 }
 
-export default function CTAButton({ href, children, event, className = 'inline-flex items-center justify-center rounded-[6px] bg-blood px-8 py-5 text-sm font-bold text-silver shadow-md transition hover:scale-105 hover:bg-crimson cta-glow ripple-hover' }: CTAButtonProps) {
+export default function CTAButton({
+  href,
+  children,
+  event,
+  className =
+    'inline-flex items-center justify-center rounded-[6px] bg-antique/70 backdrop-blur-md px-8 py-5 text-sm font-bold text-charcoal shadow-[0_2px_6px_rgba(28,28,28,0.06),_0_8px_24px_rgba(28,28,28,0.04)] transition hover:ring-4 hover:ring-blood/50 cta-glow',
+}: CTAButtonProps) {
   return (
     <Link href={href} data-event={event} className={className}>
       {children}

--- a/src/components/common/HighlightedText.tsx
+++ b/src/components/common/HighlightedText.tsx
@@ -40,7 +40,7 @@ interface HighlightedTextProps {
 const HighlightedText: React.FC<HighlightedTextProps> = ({
   text,
   tag = 'blood',
-  highlightClassName = 'text-blood glow-blood',
+  highlightClassName = 'text-blood-glow',
   defaultClassName = 'text-charcoal',
   className,
 }) => {

--- a/src/components/global/Header.tsx
+++ b/src/components/global/Header.tsx
@@ -160,7 +160,7 @@ export default function StickyHeader({ light = false, forceGray = false }: Heade
               href="/webdev-landing"
               event="cta-navbar"
               aria-label="Start your project"
-              className="group relative ml-4 inline-flex items-center gap-2 rounded-full border border-blood bg-blood px-[clamp(1rem,2.5vw,1.5rem)] py-[clamp(0.5rem,1.2vh,0.75rem)] text-[clamp(0.875rem,1.2vw,1rem)] font-bold text-silver shadow-none transition-all duration-300 hover:scale-105 hover:bg-crimson focus-visible:outline focus-visible:outline-crimson cta-glow ripple-hover"
+              className="group relative ml-4 inline-flex items-center gap-2 rounded-full px-[clamp(1rem,2.5vw,1.5rem)] py-[clamp(0.5rem,1.2vh,0.75rem)] text-[clamp(0.875rem,1.2vw,1rem)]"
             >
             <span>Get Started</span>
             <span className="transition-transform group-hover:translate-x-1">→</span>
@@ -182,7 +182,7 @@ export default function StickyHeader({ light = false, forceGray = false }: Heade
                 href="/webdev-landing"
                 event="cta-navbar"
                 aria-label="Start your project"
-                className="mt-4 inline-flex items-center gap-2 rounded-full border border-blood bg-blood px-6 py-3 text-sm font-bold text-silver shadow-none hover:bg-crimson"
+                className="mt-4 inline-flex items-center gap-2 rounded-full px-6 py-3 text-sm"
               >
               <span>Get Started</span>
               <span className="transition-transform group-hover:translate-x-1">→</span>

--- a/src/components/homepage/Hero.tsx
+++ b/src/components/homepage/Hero.tsx
@@ -143,7 +143,7 @@ export function HeroContent({
     visible: {
       opacity: 0.9,
       y: 0,
-      transition: { delay: 1, duration: 0.6 },
+      transition: { delay: 2.4, duration: 0.6 },
     },
   };
   const ctaVariants = {
@@ -151,7 +151,7 @@ export function HeroContent({
     visible: {
       opacity: 1,
       y: 0,
-      transition: { delay: 1.5, duration: 0.6 },
+      transition: { delay: 3, duration: 0.6 },
     },
   };
   const badgeVariants = {
@@ -220,10 +220,10 @@ export function HeroContent({
                   'inline-block transition-colors duration-700',
                   forceGray
                     ? seg.text.trim() === 'Trusted by'
-                      ? 'text-blood glow-blood filter-none'
+                      ? 'text-blood-glow filter-none'
                       : 'text-gray-400 filter grayscale'
                     : seg.highlight
-                      ? 'text-blood glow-blood'
+                      ? 'text-blood-glow'
                       : 'text-charcoal'
                 )}
                 variants={wordVariants}
@@ -408,7 +408,7 @@ export default function HeroSection({ reveal: revealProp, ...props }: HeroProps 
                   key={i}
                   className={clsx(
                     seg.text.trim() === 'Trusted by'
-                      ? 'text-blood'
+                      ? 'text-blood-glow'
                       : 'text-charcoal/50'
                   )}
                 >
@@ -421,7 +421,7 @@ export default function HeroSection({ reveal: revealProp, ...props }: HeroProps 
       </motion.div>
       <div
         className={clsx(
-          'relative z-20 transition-[clip-path] duration-[2000ms] ease-in-out',
+          'relative z-20 transition-[clip-path] duration-[1000ms] ease-in-out',
           reveal ? 'clip-reveal-full' : 'clip-reveal-hidden',
         )}
       >

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -42,6 +42,10 @@
   --color-blood-rgb: 161 2 4;
   --color-crimson: #7a0000;
   --color-crimson-rgb: 122 0 0;
+  --color-muted-text: #4C4C4C;
+  --color-muted-text-rgb: 76 76 76;
+  --color-border-gray: #E4E0D9;
+  --color-border-gray-rgb: 228 224 217;
 
   /* Semantic Mappings */
   --color-bg-primary: var(--color-antique);
@@ -67,6 +71,18 @@ body {
   padding: 0;
   overflow-x: hidden;
   padding-bottom: env(safe-area-inset-bottom);
+  position: relative;
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  background-image: radial-gradient(rgba(28, 28, 28, 0.05) 1px, transparent 1px);
+  background-size: 3px 3px;
+  opacity: 0.06;
 }
 
 
@@ -149,9 +165,25 @@ img {
   .bg-charcoal { background-color: rgb(var(--color-charcoal-rgb)); }
   .text-charcoal { color: rgb(var(--color-charcoal-rgb)); }
   .bg-blood { background-color: rgb(var(--color-blood-rgb)); }
-  .text-blood { color: rgb(var(--color-blood-rgb)); }
+  .text-blood {
+    background-image: linear-gradient(to bottom, #A10204, #870003);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+  }
+  .text-blood-glow {
+    background-image: linear-gradient(to bottom, #A10204, #870003);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+    text-shadow: 0 1px 4px rgba(161, 2, 4, 0.45);
+  }
   .bg-crimson { background-color: rgb(var(--color-crimson-rgb)); }
   .text-crimson { color: rgb(var(--color-crimson-rgb)); }
+  .text-muted-text { color: rgb(var(--color-muted-text-rgb)); }
+  .bg-border-gray { background-color: rgb(var(--color-border-gray-rgb)); }
+  .text-border-gray { color: rgb(var(--color-border-gray-rgb)); }
+  .border-border-gray { border-color: rgb(var(--color-border-gray-rgb)); }
   /* Opacity variants */
   .bg-blood\/20 { background-color: rgb(var(--color-blood-rgb) / 0.2); }
   .bg-blood\/30 { background-color: rgb(var(--color-blood-rgb) / 0.3); }
@@ -290,13 +322,11 @@ img {
 
 /* Utilities for the hero reveal effect */
 .clip-reveal-hidden {
-  /* Start collapsed on the left side */
-  clip-path: inset(0 100% 0 0);
+  clip-path: polygon(0 100%, 100% 0, 100% 0, 0 100%);
 }
 
 .clip-reveal-full {
-  /* Expand horizontally to reveal the full section */
-  clip-path: inset(0 0 0 0);
+  clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
 }
 
 @keyframes glow-pulse {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,6 +16,8 @@ module.exports = {
         charcoal: 'rgb(var(--color-charcoal-rgb) / <alpha-value>)',
         blood: 'rgb(var(--color-blood-rgb) / <alpha-value>)',
         crimson: 'rgb(var(--color-crimson-rgb) / <alpha-value>)',
+        'muted-text': 'rgb(var(--color-muted-text-rgb) / <alpha-value>)',
+        'border-gray': 'rgb(var(--color-border-gray-rgb) / <alpha-value>)',
         transparent: 'transparent',
         current: 'currentColor',
       },
@@ -47,8 +49,8 @@ module.exports = {
       },
 
       clipPath: {
-        'reveal-hidden': 'polygon(0 100%, 0 100%, 0 100%, 0 100%)',
-        'reveal-full': 'polygon(0 100%, 100% 100%, 100% 0, 0 0)',
+        'reveal-hidden': 'polygon(0 100%, 100% 0, 100% 0, 0 100%)',
+        'reveal-full': 'polygon(0 0, 100% 0, 100% 100%, 0 100%)',
       },
 
       container: {
@@ -88,6 +90,8 @@ module.exports = {
     'bg-charcoal', 'text-charcoal',
     'bg-blood', 'text-blood',
     'bg-crimson', 'text-crimson',
+    'bg-border-gray', 'text-border-gray', 'border-border-gray',
+    'text-muted-text',
     // Gradient utilities for custom colors
     'from-blood', 'via-blood', 'to-blood',
     'from-olive', 'via-olive', 'to-olive',


### PR DESCRIPTION
## Summary
- add muted and border-gray color utilities
- implement diagonal reveal clip paths
- create `.text-blood` gradient and `.text-blood-glow`
- overlay pages with grayscale and noise texture
- update CTA button design with frosted glass style
- delay hero subheadline/CTA animations
- support reduced motion

## Testing
- `pnpm build:css`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688447f6535c8328990bc8bf459e18f4