### PR TITLE
Hero monogram redesign

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@fontsource/fraunces": "5.2.6",
     "@fontsource/gfs-didot": "^5.2.6",
     "@fontsource/space-grotesk": "^5.2.8",
     "@radix-ui/react-dialog": "^1.1.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
 
   .:
     dependencies:
+      '@fontsource/fraunces':
+        specifier: 5.2.6
+        version: 5.2.6
       '@fontsource/gfs-didot':
         specifier: ^5.2.6
         version: 5.2.6
@@ -1034,6 +1037,9 @@ packages:
 
   '@floating-ui/utils@0.2.9':
     resolution: {integrity: sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==}
+
+  '@fontsource/fraunces@5.2.6':
+    resolution: {integrity: sha512-jif5QR10IW7bbIN1CLh/dOj2KXf7KKzeyDNbodeKGPbONIUYARzZ4CemD0aooZqbvx8OFnL4/1Jt0M2j2CYbhw==}
 
   '@fontsource/gfs-didot@5.2.6':
     resolution: {integrity: sha512-peUsK6Pzy+saQYXNLlyQSlYQE7lyLkRzc/YkqxAIuutGjlAHVqB4FYL9yAss5Cn6oVdZB8iiB7iSdP2rzWqChA==}
@@ -8087,6 +8093,8 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
 
   '@floating-ui/utils@0.2.9': {}
+
+  '@fontsource/fraunces@5.2.6': {}
 
   '@fontsource/gfs-didot@5.2.6': {}
 

--- a/public/textures/engrave.svg
+++ b/public/textures/engrave.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" stroke="black" stroke-opacity="0.4" stroke-width="1" fill="none">
+  <path d="M0 0L20 20M20 0L0 20"/>
+</svg>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,11 +9,23 @@ import '@fontsource/gfs-didot/400.css';
 import '@fontsource/space-grotesk/400.css';
 import '@fontsource/space-grotesk/500.css';
 import '@fontsource/space-grotesk/700.css';
+import '@fontsource/fraunces/600.css';
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   useEffect(() => {
     document.documentElement.style.overflowY = 'auto';
     document.body.style.overflowY = 'auto';
+    document.documentElement.classList.add('grayscale');
+    const start = setTimeout(() => {
+      document.documentElement.classList.add('grayscale-reveal');
+    }, 2600);
+    const end = setTimeout(() => {
+      document.documentElement.classList.remove('grayscale', 'grayscale-reveal');
+    }, 4200);
+    return () => {
+      clearTimeout(start);
+      clearTimeout(end);
+    };
   }, []);
 
   return (

--- a/src/components/homepage/Hero.tsx
+++ b/src/components/homepage/Hero.tsx
@@ -211,7 +211,7 @@ export function HeroContent({
             data-scroll
             variants={textVariants}
             custom={1}
-            className="mb-6 ml-20 w-full text-charcoal text-[clamp(2.5rem,6vw,4.5rem)] leading-[1.1] font-grotesk font-bold tracking-tight"
+            className="mb-6 ml-20 w-full text-charcoal text-[clamp(3rem,8vw,6rem)] leading-[1.05] font-fraunces font-semibold tracking-tight drop-shadow-[0_1.5px_3px_#3d0002]"
           >
             {headlineSegments.map((seg, si) => (
               <motion.span
@@ -308,7 +308,7 @@ export function HeroContent({
               initial={{ opacity: 0, y: -20 }}
               animate={{ opacity: 1, y: 0, transition: { delay: 1, duration: 1, ease: 'easeIn' } }}
               style={{ opacity: letter === 'R' ? rOpacity : 1 }}
-              className="block font-grotesk font-extrabold uppercase leading-none text-sepia text-[45vh]"
+              className="npr-monogram block font-fraunces font-extrabold uppercase leading-none text-sepia text-[45vh]"
             >
               {letter}
             </motion.span>
@@ -402,7 +402,7 @@ export default function HeroSection({ reveal: revealProp, ...props }: HeroProps 
             <div className="mb-6 ml-20 text-[clamp(0.85rem,1.2vw,0.9rem)] font-thin tracking-widest text-charcoal invisible">
               HELLO, WE ARE NPR MEDIA
             </div>
-            <h1 className="mb-6 ml-20 w-full text-charcoal/30 text-[clamp(2.5rem,6vw,4.5rem)] leading-[1.1] font-grotesk font-bold tracking-tight">
+            <h1 className="mb-6 ml-20 w-full text-charcoal/30 text-[clamp(3rem,8vw,6rem)] leading-[1.05] font-fraunces font-semibold tracking-tight drop-shadow-[0_1.5px_3px_#3d0002]">
               {overlaySegments.map((seg, i) => (
                 <span
                   key={i}

--- a/src/content/homepage/hero.ts
+++ b/src/content/homepage/hero.ts
@@ -14,7 +14,7 @@ export interface HeroProps {
 }
 
 export const hero: HeroProps = {
-  headline: 'Trusted by [blood]Founders Who Don’t Get a[/blood] [blood]Second Shot.[/blood]',
+  headline: 'Trusted by Founders Who Don’t Get a [blood]Second Shot[/blood][blood].[/blood]',
   subheadline: '70% of startups fail between years 2–5 — a weak website is one of the fastest ways to join them.',
   ctaText: 'Make Sure Your Website Isn’t the Reason',
   ctaLink: '/webdev-landing',

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -18,7 +18,7 @@
   --section-padding: 6rem;
   --max-content-width: 1280px;
 
-  --font-heading: 'Inter', sans-serif;
+  --font-heading: 'Fraunces', serif;
   --font-body: 'Inter', sans-serif;
   --font-didot: 'GFS Didot', serif;
   --font-grotesk: 'Space Grotesk', sans-serif;
@@ -360,4 +360,37 @@ img {
     box-shadow: 0 0 0 12px rgb(var(--color-blood-rgb) / 0);
     opacity: 0;
   }
+}
+
+@keyframes grayscaleSweep315 {
+  from {
+    -webkit-mask-image: linear-gradient(315deg, black 0%, transparent 100%);
+    mask-image: linear-gradient(315deg, black 0%, transparent 100%);
+  }
+  to {
+    -webkit-mask-image: linear-gradient(315deg, transparent 0%, transparent 100%);
+    mask-image: linear-gradient(315deg, transparent 0%, transparent 100%);
+  }
+}
+
+html.grayscale {
+  filter: grayscale(1);
+}
+
+html.grayscale.grayscale-reveal {
+  animation: grayscaleSweep315 1.6s ease-out forwards;
+}
+
+.text-blood-glow {
+  filter: none;
+}
+
+.npr-monogram {
+  opacity: 0.08;
+  mix-blend-mode: overlay;
+  -webkit-mask-image: url('/textures/engrave.svg');
+  mask-image: url('/textures/engrave.svg');
+  mask-size: 200%;
+  mask-repeat: repeat;
+  text-shadow: 0 0 8px rgba(183, 160, 119, 0.6);
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -25,6 +25,7 @@ module.exports = {
       fontFamily: {
         didot: ['"GFS Didot"', 'serif'],
         grotesk: ['"Space Grotesk"', 'sans-serif'],
+        fraunces: ['"Fraunces"', 'serif'],
         sans: ['Inter', ...defaultTheme.fontFamily.sans],
         code: ['JetBrains Mono', 'monospace'],
       },


### PR DESCRIPTION
## Summary
- highlight "Second Shot" and final period in hero copy
- swap to Fraunces heading font and expose via Tailwind config
- apply grayscale sweep reveal on page load
- stylize giant NPR letters with texture and glow
- add simple engrave texture asset

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6886a8a04df88328b65cf49dec78611f