### PR TITLE
Refine hero with ritual NPR monogram

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@fontsource/fraunces": "5.2.7",
     "@fontsource/gfs-didot": "^5.2.6",
     "@fontsource/space-grotesk": "^5.2.8",
     "@radix-ui/react-dialog": "^1.1.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
 
   .:
     dependencies:
+      '@fontsource/fraunces':
+        specifier: 5.2.7
+        version: 5.2.7
       '@fontsource/gfs-didot':
         specifier: ^5.2.6
         version: 5.2.6
@@ -1034,6 +1037,9 @@ packages:
 
   '@floating-ui/utils@0.2.9':
     resolution: {integrity: sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==}
+
+  '@fontsource/fraunces@5.2.7':
+    resolution: {integrity: sha512-/Dayni4YeluyJ0VArMKJ3KXAe4GePW9SJ5DWorZJUOB0ESHrR4g9J3s0+gklVNDlIaqpc7krFvBwC7SOBeUFog==}
 
   '@fontsource/gfs-didot@5.2.6':
     resolution: {integrity: sha512-peUsK6Pzy+saQYXNLlyQSlYQE7lyLkRzc/YkqxAIuutGjlAHVqB4FYL9yAss5Cn6oVdZB8iiB7iSdP2rzWqChA==}
@@ -8087,6 +8093,8 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
 
   '@floating-ui/utils@0.2.9': {}
+
+  '@fontsource/fraunces@5.2.7': {}
 
   '@fontsource/gfs-didot@5.2.6': {}
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -511,6 +511,9 @@
 .animate-\[bounce_2\.5s_infinite\] {
   animation: bounce 2.5s infinite;
 }
+.animate-\[grayscaleSweep315_1\.6s_ease-out_forwards\] {
+  animation: grayscaleSweep315 1.6s ease-out forwards;
+}
 .animate-bounce {
   animation: var(--animate-bounce);
 }
@@ -737,6 +740,10 @@
   --tw-gradient-position: to top in oklab;
   background-image: linear-gradient(var(--tw-gradient-stops));
 }
+.bg-gradient-to-tr {
+  --tw-gradient-position: to top right in oklab;
+  background-image: linear-gradient(var(--tw-gradient-stops));
+}
 .bg-\[linear-gradient\(270deg\,var\(--tw-gradient-stops\)\)\] {
   background-image: linear-gradient(270deg,var(--tw-gradient-stops));
 }
@@ -745,6 +752,10 @@
 }
 .bg-\[radial-gradient\(circle_at_center\,var\(--tw-gradient-stops\)\)\] {
   background-image: radial-gradient(circle at center,var(--tw-gradient-stops));
+}
+.from-\[\#D1C4A8\] {
+  --tw-gradient-from: #D1C4A8;
+  --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
 }
 .from-black\/20 {
   --tw-gradient-from: color-mix(in srgb, #000 20%, transparent);
@@ -773,6 +784,10 @@
   }
   --tw-gradient-via-stops: var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-via) var(--tw-gradient-via-position), var(--tw-gradient-to) var(--tw-gradient-to-position);
   --tw-gradient-stops: var(--tw-gradient-via-stops);
+}
+.to-\[\#F9F6F1\] {
+  --tw-gradient-to: #F9F6F1;
+  --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
 }
 .to-transparent {
   --tw-gradient-to: transparent;
@@ -1007,8 +1022,8 @@
 .text-\[0\.65rem\] {
   font-size: 0.65rem;
 }
-.text-\[45vh\] {
-  font-size: 45vh;
+.text-\[25vw\] {
+  font-size: 25vw;
 }
 .text-\[clamp\(0\.7rem\,1vw\,0\.8rem\)\] {
   font-size: clamp(0.7rem, 1vw, 0.8rem);
@@ -1072,6 +1087,9 @@
 }
 .text-\[clamp\(2rem\,5vw\,3rem\)\] {
   font-size: clamp(2rem, 5vw, 3rem);
+}
+.text-\[clamp\(3rem\,6vw\,6rem\)\] {
+  font-size: clamp(3rem, 6vw, 6rem);
 }
 .leading-\[1\.1\] {
   --tw-leading: 1.1;
@@ -1262,6 +1280,16 @@
   --tw-blur: blur(var(--blur-3xl));
   filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
 }
+.drop-shadow-\[0_1\.5px_3px_\#3d0002\] {
+  --tw-drop-shadow-size: drop-shadow(0 1.5px 3px var(--tw-drop-shadow-color, #3d0002));
+  --tw-drop-shadow: var(--tw-drop-shadow-size);
+  filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
+}
+.drop-shadow-\[0_1px_2px_rgba\(0\,0\,0\,0\.2\)\] {
+  --tw-drop-shadow-size: drop-shadow(0 1px 2px var(--tw-drop-shadow-color, rgba(0,0,0,0.2)));
+  --tw-drop-shadow: var(--tw-drop-shadow-size);
+  filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
+}
 .grayscale {
   --tw-grayscale: grayscale(100%);
   filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
@@ -1348,6 +1376,10 @@
 .duration-\[1000ms\] {
   --tw-duration: 1000ms;
   transition-duration: 1000ms;
+}
+.duration-\[1600ms\] {
+  --tw-duration: 1600ms;
+  transition-duration: 1600ms;
 }
 .duration-\[2000ms\] {
   --tw-duration: 2000ms;
@@ -1787,6 +1819,10 @@
   --color-blood-rgb: 154 0 3;
   --color-crimson: #7a0000;
   --color-crimson-rgb: 122 0 0;
+  --color-ivory: #F9F6F1;
+  --color-ivory-rgb: 249 246 241;
+  --color-gold-muted: #D1C4A8;
+  --color-gold-muted-rgb: 209 196 168;
   --color-muted-text: #464442;
   --color-muted-text-rgb: 70 68 66;
   --color-border-gray: #DBD6CE;
@@ -1941,6 +1977,15 @@ img {
   }
   .text-crimson {
     color: rgb(var(--color-crimson-rgb));
+  }
+  .bg-ivory {
+    background-color: rgb(var(--color-ivory-rgb));
+  }
+  .text-ivory {
+    color: rgb(var(--color-ivory-rgb));
+  }
+  .text-gold-muted {
+    color: rgb(var(--color-gold-muted-rgb));
   }
   .text-muted-text {
     color: rgb(var(--color-muted-text-rgb));
@@ -2150,6 +2195,14 @@ img {
   100% {
     box-shadow: 0 0 0 12px rgb(var(--color-blood-rgb) / 0);
     opacity: 0;
+  }
+}
+@keyframes grayscaleSweep315 {
+  from {
+    clip-path: polygon(0 100%, 100% 0, 100% 0, 0 100%);
+  }
+  to {
+    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
   }
 }
 @property --tw-translate-x {

--- a/public/textures/engrave.svg
+++ b/public/textures/engrave.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100">
+  <defs>
+    <filter id="noise" x="0" y="0" width="100%" height="100%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.8" numOctaves="3" stitchTiles="stitch"/>
+    </filter>
+  </defs>
+  <rect width="100" height="100" filter="url(#noise)"/>
+</svg>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,8 @@ import '@fontsource/gfs-didot/400.css';
 import '@fontsource/space-grotesk/400.css';
 import '@fontsource/space-grotesk/500.css';
 import '@fontsource/space-grotesk/700.css';
+import '@fontsource/fraunces/600.css';
+import '@fontsource/fraunces/700.css';
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   useEffect(() => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,7 +22,7 @@ export default function Page() {
   }, []);
 
   useEffect(() => {
-    const delay = prefersReduced ? 0 : 1400;
+    const delay = prefersReduced ? 0 : 2600;
     const timer = setTimeout(() => setReveal(true), delay);
     return () => clearTimeout(timer);
   }, [prefersReduced]);
@@ -33,7 +33,9 @@ export default function Page() {
       <div
         className={clsx(
           'pointer-events-none fixed inset-0 z-[60] backdrop-grayscale',
-          prefersReduced ? 'transition-none' : 'transition-[clip-path] duration-[1000ms] ease-in-out',
+          prefersReduced
+            ? 'transition-none'
+            : 'transition-[clip-path] duration-[1600ms] ease-out animate-[grayscaleSweep315_1.6s_ease-out_forwards]',
           reveal ? 'clip-reveal-hidden' : 'clip-reveal-full'
         )}
       />

--- a/src/components/homepage/Hero.tsx
+++ b/src/components/homepage/Hero.tsx
@@ -180,7 +180,7 @@ export function HeroContent({
       ref={heroRef}
       aria-label="Hero Section"
       style={{ scale: heroScale, opacity: heroOpacity, willChange: 'transform, opacity' }}
-      className="relative min-h-[100svh] pb-[5vh] flex items-center justify-center bg-antique font-sans overflow-hidden"
+      className="relative min-h-[100svh] pb-[5vh] flex items-center justify-center bg-gradient-to-tr from-[#D1C4A8] to-[#F9F6F1] font-sans overflow-hidden"
     >
       <div
         ref={containerRef}
@@ -211,7 +211,7 @@ export function HeroContent({
             data-scroll
             variants={textVariants}
             custom={1}
-            className="mb-6 ml-20 w-full text-charcoal text-[clamp(2.5rem,6vw,4.5rem)] leading-[1.1] font-grotesk font-bold tracking-tight"
+            className="mb-6 ml-20 w-full text-charcoal text-[clamp(3rem,6vw,6rem)] leading-[1.1] font-fraunces font-semibold tracking-tight drop-shadow-[0_1.5px_3px_#3d0002]"
           >
             {headlineSegments.map((seg, si) => (
               <motion.span
@@ -232,6 +232,7 @@ export function HeroContent({
                 {seg.text}
               </motion.span>
             ))}
+            <span className="text-blood-glow">.</span>
           </motion.h1>
           {subheadline && (
             <motion.p
@@ -292,15 +293,21 @@ export function HeroContent({
       </div>
 
       <div
-        className="pointer-events-none absolute bottom-0 z-0 hidden -translate-x-1/2 md:flex justify-center mix-blend-overlay"
-        style={{ left: '80%', width: '25%' }}
+        className="pointer-events-none absolute inset-0 z-0 hidden md:flex justify-center"
+        style={{ left: '55%', width: '40%' }}
       >
         <motion.div
           ref={overlayRef}
-          style={{ y: overlayY, willChange: 'transform' }}
+          style={{
+            y: overlayY,
+            willChange: 'transform',
+            maskImage: "url('/textures/engrave.svg')",
+            WebkitMaskImage: "url('/textures/engrave.svg')",
+            maskSize: 'cover',
+          }}
           initial="hidden"
           animate="visible"
-          className={clsx('flex h-[200%] flex-col items-center pb-[5vh]', forceGray && 'filter grayscale')}
+          className={clsx('flex h-[200%] flex-col items-center pb-[5vh] mix-blend-overlay opacity-90', forceGray && 'filter grayscale')}
         >
           {['N', 'P', 'R'].map((letter) => (
             <motion.span
@@ -308,7 +315,7 @@ export function HeroContent({
               initial={{ opacity: 0, y: -20 }}
               animate={{ opacity: 1, y: 0, transition: { delay: 1, duration: 1, ease: 'easeIn' } }}
               style={{ opacity: letter === 'R' ? rOpacity : 1 }}
-              className="block font-grotesk font-extrabold uppercase leading-none text-sepia text-[45vh]"
+              className="block font-fraunces font-bold uppercase leading-none text-gold-muted text-[25vw] drop-shadow-[0_1px_2px_rgba(0,0,0,0.2)]"
             >
               {letter}
             </motion.span>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -42,6 +42,10 @@
   --color-blood-rgb: 154 0 3;
   --color-crimson: #7a0000;
   --color-crimson-rgb: 122 0 0;
+  --color-ivory: #F9F6F1;
+  --color-ivory-rgb: 249 246 241;
+  --color-gold-muted: #D1C4A8;
+  --color-gold-muted-rgb: 209 196 168;
   --color-muted-text: #464442;
   --color-muted-text-rgb: 70 68 66;
   --color-border-gray: #DBD6CE;
@@ -180,6 +184,9 @@ img {
   }
   .bg-crimson { background-color: rgb(var(--color-crimson-rgb)); }
   .text-crimson { color: rgb(var(--color-crimson-rgb)); }
+  .bg-ivory { background-color: rgb(var(--color-ivory-rgb)); }
+  .text-ivory { color: rgb(var(--color-ivory-rgb)); }
+  .text-gold-muted { color: rgb(var(--color-gold-muted-rgb)); }
   .text-muted-text { color: rgb(var(--color-muted-text-rgb)); }
   .bg-border-gray { background-color: rgb(var(--color-border-gray-rgb)); }
   .text-border-gray { color: rgb(var(--color-border-gray-rgb)); }
@@ -359,5 +366,14 @@ img {
   100% {
     box-shadow: 0 0 0 12px rgb(var(--color-blood-rgb) / 0);
     opacity: 0;
+  }
+}
+
+@keyframes grayscaleSweep315 {
+  from {
+    clip-path: polygon(0 100%, 100% 0, 100% 0, 0 100%);
+  }
+  to {
+    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,6 +16,8 @@ module.exports = {
         charcoal: 'rgb(var(--color-charcoal-rgb) / <alpha-value>)',
         blood: 'rgb(var(--color-blood-rgb) / <alpha-value>)',
         crimson: 'rgb(var(--color-crimson-rgb) / <alpha-value>)',
+        ivory: 'rgb(var(--color-ivory-rgb) / <alpha-value>)',
+        'gold-muted': 'rgb(var(--color-gold-muted-rgb) / <alpha-value>)',
         'muted-text': 'rgb(var(--color-muted-text-rgb) / <alpha-value>)',
         'border-gray': 'rgb(var(--color-border-gray-rgb) / <alpha-value>)',
         transparent: 'transparent',
@@ -27,6 +29,7 @@ module.exports = {
         grotesk: ['"Space Grotesk"', 'sans-serif'],
         sans: ['Inter', ...defaultTheme.fontFamily.sans],
         code: ['JetBrains Mono', 'monospace'],
+        fraunces: ['"Fraunces"', 'serif'],
       },
 
       fontSize: {
@@ -90,6 +93,8 @@ module.exports = {
     'bg-charcoal', 'text-charcoal',
     'bg-blood', 'text-blood',
     'bg-crimson', 'text-crimson',
+    'bg-ivory', 'text-ivory',
+    'text-gold-muted',
     'bg-border-gray', 'text-border-gray', 'border-border-gray',
     'text-muted-text',
     // Gradient utilities for custom colors


### PR DESCRIPTION
## Summary
- import Fraunces font
- add gold-muted and ivory colors
- implement grayscale sweep animation
- redesign hero headline and NPR monogram
- add engrave texture asset

## Testing
- `pnpm build:css`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6886a8a04df88328b65cf49dec78611f