### PR TITLE
Refactor values carousel into grouped sections

### DIFF
--- a/src/components/about/ValuesCarousel.tsx
+++ b/src/components/about/ValuesCarousel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { motion } from 'framer-motion';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import clsx from 'clsx';
 
 type Slide = {
@@ -12,11 +12,15 @@ type Slide = {
 type SlideGroup = {
   heading: string;
   cards: Slide[];
+  axis: 'x' | 'y' | 'paged';
+  motionKey: 'values' | 'culture' | 'beliefs';
 };
 
 const slideGroups: SlideGroup[] = [
   {
     heading: 'Values',
+    axis: 'y',
+    motionKey: 'values',
     cards: [
       {
         title: 'Results Over Vanity',
@@ -37,6 +41,8 @@ const slideGroups: SlideGroup[] = [
   },
   {
     heading: 'Culture',
+    axis: 'x',
+    motionKey: 'culture',
     cards: [
       {
         title: 'Learn and Iterate',
@@ -57,6 +63,8 @@ const slideGroups: SlideGroup[] = [
   },
   {
     heading: 'Beliefs',
+    axis: 'paged',
+    motionKey: 'beliefs',
     cards: [
       {
         title: 'Partners Not Vendors',
@@ -82,34 +90,114 @@ export interface ValuesCarouselProps {
 }
 
 export default function ValuesCarousel({ className }: ValuesCarouselProps) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const [index, setIndex] = useState(0);
+  const groupRefs = useRef<Record<string, HTMLDivElement | null>>({});
+  const [activeIndices, setActiveIndices] = useState<Record<string, number>>(() =>
+    Object.fromEntries(slideGroups.map((group) => [group.heading, 0])),
+  );
+  const activeIndicesRef = useRef(activeIndices);
 
-  const slides = slideGroups.flatMap((group) =>
-    group.cards.map((card) => ({ ...card, groupHeading: group.heading })),
+  const motionConfigs = useMemo(
+    () =>
+      ({
+        values: {
+          initial: { opacity: 0, y: 32 },
+          animate: { opacity: 1, y: 0 },
+          transition: { duration: 0.45, ease: 'easeOut' },
+        },
+        culture: {
+          initial: { opacity: 0, x: 48 },
+          animate: { opacity: 1, x: 0 },
+          transition: { duration: 0.5, ease: 'easeOut' },
+        },
+        beliefs: {
+          initial: { opacity: 0, x: -24, y: 24, scale: 0.92 },
+          animate: { opacity: 1, x: 0, y: 0, scale: 1 },
+          transition: { duration: 0.55, ease: 'easeOut' },
+        },
+      } as const),
+    [],
   );
 
   useEffect(() => {
-    const container = containerRef.current;
-    if (!container) return;
-    const onScroll = () => {
-      const center = container.scrollTop + container.clientHeight / 2;
-      const children = Array.from(container.children) as HTMLElement[];
-      let closest = 0;
-      let minDistance = Infinity;
-      children.forEach((child, i) => {
-        const childCenter = child.offsetTop + child.clientHeight / 2;
-        const distance = Math.abs(childCenter - center);
-        if (distance < minDistance) {
-          minDistance = distance;
-          closest = i;
-        }
-      });
-      setIndex(closest);
+    activeIndicesRef.current = activeIndices;
+  }, [activeIndices]);
+
+  useEffect(() => {
+    const cleanups = slideGroups.map((group) => {
+      const container = groupRefs.current[group.heading];
+      if (!container) return undefined;
+      const isHorizontal = group.axis === 'x';
+
+      const handleScroll = () => {
+        const center = isHorizontal
+          ? container.scrollLeft + container.clientWidth / 2
+          : container.scrollTop + container.clientHeight / 2;
+        const children = Array.from(container.children) as HTMLElement[];
+        let closest = 0;
+        let minDistance = Infinity;
+        children.forEach((child, index) => {
+          const childCenter = isHorizontal
+            ? child.offsetLeft + child.clientWidth / 2
+            : child.offsetTop + child.clientHeight / 2;
+          const distance = Math.abs(childCenter - center);
+          if (distance < minDistance) {
+            minDistance = distance;
+            closest = index;
+          }
+        });
+        setActiveIndices((prev) => {
+          if (prev[group.heading] === closest) return prev;
+          return { ...prev, [group.heading]: closest };
+        });
+      };
+
+      container.addEventListener('scroll', handleScroll, { passive: true });
+      handleScroll();
+      return () => container.removeEventListener('scroll', handleScroll);
+    });
+
+    return () => {
+      cleanups.forEach((cleanup) => cleanup?.());
     };
-    container.addEventListener('scroll', onScroll);
-    onScroll();
-    return () => container.removeEventListener('scroll', onScroll);
+  }, []);
+
+  useEffect(() => {
+    const beliefsContainer = groupRefs.current['Beliefs'];
+    if (!beliefsContainer) return;
+
+    let ticking = false;
+
+    const handleWheel = (event: WheelEvent) => {
+      if (!beliefsContainer) return;
+      if (Math.abs(event.deltaY) <= Math.abs(event.deltaX)) return;
+      event.preventDefault();
+      if (ticking) return;
+      ticking = true;
+
+      const direction = event.deltaY > 0 ? 1 : -1;
+      const children = Array.from(beliefsContainer.children) as HTMLElement[];
+      const currentIndex = activeIndicesRef.current['Beliefs'] ?? 0;
+      const nextIndex = Math.min(
+        Math.max(currentIndex + direction, 0),
+        Math.max(children.length - 1, 0),
+      );
+      const target = children[nextIndex];
+      if (target) {
+        const targetRect = target.getBoundingClientRect();
+        const containerRect = beliefsContainer.getBoundingClientRect();
+        const offset = targetRect.top - containerRect.top + beliefsContainer.scrollTop;
+        beliefsContainer.scrollTo({
+          top: offset,
+          behavior: 'smooth',
+        });
+      }
+      window.setTimeout(() => {
+        ticking = false;
+      }, 400);
+    };
+
+    beliefsContainer.addEventListener('wheel', handleWheel, { passive: false });
+    return () => beliefsContainer.removeEventListener('wheel', handleWheel);
   }, []);
 
   return (
@@ -141,34 +229,59 @@ export default function ValuesCarousel({ className }: ValuesCarouselProps) {
         </h2>
       </div>
       <div
-        ref={containerRef}
-        className="no-scrollbar h-full snap-y snap-mandatory overflow-y-scroll scroll-smooth pb-12 pt-6"
+        className="no-scrollbar h-full overflow-y-scroll scroll-smooth pb-12 pt-6"
       >
-        {slides.map((slide, i) => {
-          const distance = Math.abs(index - i);
-          const opacity = 1 - Math.min(distance * 0.4, 0.8);
-          const showHeading =
-            i === 0 || slides[i - 1]?.groupHeading !== slide.groupHeading;
-          return (
-            <section key={slide.title} className="snap-center py-4">
-              {showHeading && (
-                <p className="mb-3 text-sm font-semibold uppercase tracking-wide text-antique/80">
-                  {slide.groupHeading}
+        <div className="space-y-10 px-6">
+          {slideGroups.map((group) => {
+            const activeIndex = activeIndices[group.heading] ?? 0;
+            const isHorizontal = group.axis === 'x';
+            const containerClasses = clsx(
+              'group/card no-scrollbar flex gap-6',
+              group.axis === 'y' &&
+                'h-[22rem] snap-y snap-mandatory flex-col overflow-y-scroll pb-4',
+              isHorizontal &&
+                'snap-x snap-mandatory overflow-x-scroll pb-4 flex-nowrap',
+              group.axis === 'paged' &&
+                'h-[22rem] snap-y snap-mandatory flex-col overflow-y-scroll pb-4 scroll-py-6',
+            );
+            return (
+              <section key={group.heading} className="space-y-4">
+                <p className="text-center text-lg font-semibold uppercase tracking-[0.3em] text-antique/80">
+                  {group.heading}
                 </p>
-              )}
-              <motion.div
-                initial={{ opacity: 0, y: 20 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.4 }}
-                style={{ opacity }}
-                className="rounded-xl bg-antique p-6 text-charcoal shadow-silver/20"
-              >
-                <p className="text-xl leading-snug font-bold">{slide.title}</p>
-                <p className="mt-2 text-lg leading-relaxed text-charcoal">{slide.description}</p>
-              </motion.div>
-            </section>
-          );
-        })}
+                <div
+                  ref={(node) => {
+                    groupRefs.current[group.heading] = node;
+                  }}
+                  className={containerClasses}
+                >
+                  {group.cards.map((card, cardIndex) => {
+                    const distance = Math.abs(activeIndex - cardIndex);
+                    const opacity = 1 - Math.min(distance * 0.4, 0.8);
+                    const motionConfig = motionConfigs[group.motionKey];
+                    return (
+                      <motion.div
+                        key={card.title}
+                        initial={motionConfig.initial}
+                        animate={motionConfig.animate}
+                        transition={motionConfig.transition}
+                        style={{ opacity }}
+                        className={clsx(
+                          'snap-center rounded-xl bg-antique p-6 text-charcoal shadow-silver/20',
+                          isHorizontal && 'min-w-[calc(100%-1.5rem)] shrink-0',
+                          group.axis === 'paged' && 'snap-always',
+                        )}
+                      >
+                        <p className="text-xl font-bold leading-snug">{card.title}</p>
+                        <p className="mt-2 text-lg leading-relaxed text-charcoal">{card.description}</p>
+                      </motion.div>
+                    );
+                  })}
+                </div>
+              </section>
+            );
+          })}
+        </div>
       </div>
     </div>
   );

--- a/src/components/about/ValuesCarousel.tsx
+++ b/src/components/about/ValuesCarousel.tsx
@@ -117,8 +117,8 @@ function CarouselCard({
 }) {
   const distance = Math.abs(activeIndex - cardIndex);
   const opacity = 1 - Math.min(distance * 0.4, 0.8);
-  const isCulture = group.motionKey === 'culture';
-  const targetScale = isCulture ? cultureScaleForDistance(distance) : 1;
+  const targetScale =
+    group.motionKey === 'culture' ? cultureScaleForDistance(distance) : 1;
   const scaleSpring = useSpring(targetScale, {
     stiffness: 220,
     damping: 28,
@@ -129,14 +129,15 @@ function CarouselCard({
     scaleSpring.set(targetScale);
   }, [scaleSpring, targetScale]);
 
-  const style: MotionStyle = {
+  const outerStyle: MotionStyle = {
     opacity,
-    transformOrigin: 'center center',
   };
 
-  if (isCulture) {
-    style.scale = scaleSpring;
-  }
+  const innerStyle: MotionStyle = {
+    transformOrigin: 'center center',
+    scaleX: scaleSpring,
+    scaleY: scaleSpring,
+  };
 
   return (
     <motion.div
@@ -144,18 +145,25 @@ function CarouselCard({
       initial={motionConfig.initial}
       animate={motionConfig.animate}
       transition={motionConfig.transition}
-      style={style}
+      style={outerStyle}
       className={clsx(
-        'snap-center rounded-xl bg-antique p-6 text-charcoal shadow-silver/20',
+        'snap-center flex w-full justify-center',
         isHorizontal && 'min-w-[calc(100%-1.5rem)] shrink-0',
         group.axis === 'paged' && 'snap-always',
-        isCulture && 'will-change-transform',
       )}
     >
-      <p className="text-xl font-bold leading-snug">{card.title}</p>
-      <p className="mt-2 text-lg leading-relaxed text-charcoal">
-        {card.description}
-      </p>
+      <motion.div
+        style={innerStyle}
+        className={clsx(
+          'w-full rounded-xl bg-antique p-6 text-charcoal shadow-silver/20',
+          group.motionKey === 'culture' && 'will-change-transform',
+        )}
+      >
+        <p className="text-xl font-bold leading-snug">{card.title}</p>
+        <p className="mt-2 text-lg leading-relaxed text-charcoal">
+          {card.description}
+        </p>
+      </motion.div>
     </motion.div>
   );
 }

--- a/src/components/about/ValuesCarousel.tsx
+++ b/src/components/about/ValuesCarousel.tsx
@@ -9,51 +9,71 @@ type Slide = {
   description: string;
 };
 
-const slides: Slide[] = [
+type SlideGroup = {
+  heading: string;
+  cards: Slide[];
+};
+
+const slideGroups: SlideGroup[] = [
   {
-    title: 'Value: Results Over Vanity',
-    description:
-      'Real growth matters most. Vanity metrics may look nice but rarely move the needle. Every feature ties back to concrete business results.',
+    heading: 'Values',
+    cards: [
+      {
+        title: 'Results Over Vanity',
+        description:
+          'Real growth matters most. Vanity metrics may look nice but rarely move the needle. Every feature ties back to concrete business results.',
+      },
+      {
+        title: 'Transparency Always',
+        description:
+          'Open communication builds trust. We share progress often so there are no surprises. Clear expectations set the stage for great partnerships.',
+      },
+      {
+        title: 'Simplicity Wins',
+        description:
+          'Complex sites slow teams down. We keep code lean so your product stays fast. Simple solutions are easier to maintain and extend.',
+      },
+    ],
   },
   {
-    title: 'Value: Transparency Always',
-    description:
-      'Open communication builds trust. We share progress often so there are no surprises. Clear expectations set the stage for great partnerships.',
+    heading: 'Culture',
+    cards: [
+      {
+        title: 'Learn and Iterate',
+        description:
+          'We experiment constantly to improve. Each project teaches us something new. Continuous learning keeps our work fresh and effective.',
+      },
+      {
+        title: 'Ownership Mentality',
+        description:
+          'We step up like it is our own product. Taking responsibility yields better outcomes. Everyone on the team is accountable for quality.',
+      },
+      {
+        title: 'Remote Friendly',
+        description:
+          'Great talent lives everywhere. Our flexible approach lets us collaborate with the best people anywhere. Being remote keeps us nimble.',
+      },
+    ],
   },
   {
-    title: 'Value: Simplicity Wins',
-    description:
-      'Complex sites slow teams down. We keep code lean so your product stays fast. Simple solutions are easier to maintain and extend.',
-  },
-  {
-    title: 'Culture: Learn and Iterate',
-    description:
-      'We experiment constantly to improve. Each project teaches us something new. Continuous learning keeps our work fresh and effective.',
-  },
-  {
-    title: 'Culture: Ownership Mentality',
-    description:
-      'We step up like it is our own product. Taking responsibility yields better outcomes. Everyone on the team is accountable for quality.',
-  },
-  {
-    title: 'Culture: Remote Friendly',
-    description:
-      'Great talent lives everywhere. Our flexible approach lets us collaborate with the best people anywhere. Being remote keeps us nimble.',
-  },
-  {
-    title: 'Belief: Partners Not Vendors',
-    description:
-      'True success comes from collaboration. We embed with your team to understand every goal. You get a dedicated partner, not just another vendor.',
-  },
-  {
-    title: 'Belief: People Over Process',
-    description:
-      'Rigid frameworks slow innovation. We adapt methods to fit your business. Strong relationships drive outcomes more than strict processes.',
-  },
-  {
-    title: 'Belief: Long-Term Success',
-    description:
-      'We build to last and grow. Scalable systems ensure your investment keeps delivering. Solutions should stand the test of time.',
+    heading: 'Beliefs',
+    cards: [
+      {
+        title: 'Partners Not Vendors',
+        description:
+          'True success comes from collaboration. We embed with your team to understand every goal. You get a dedicated partner, not just another vendor.',
+      },
+      {
+        title: 'People Over Process',
+        description:
+          'Rigid frameworks slow innovation. We adapt methods to fit your business. Strong relationships drive outcomes more than strict processes.',
+      },
+      {
+        title: 'Long-Term Success',
+        description:
+          'We build to last and grow. Scalable systems ensure your investment keeps delivering. Solutions should stand the test of time.',
+      },
+    ],
   },
 ];
 
@@ -64,6 +84,10 @@ export interface ValuesCarouselProps {
 export default function ValuesCarousel({ className }: ValuesCarouselProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [index, setIndex] = useState(0);
+
+  const slides = slideGroups.flatMap((group) =>
+    group.cards.map((card) => ({ ...card, groupHeading: group.heading })),
+  );
 
   useEffect(() => {
     const container = containerRef.current;
@@ -111,15 +135,27 @@ export default function ValuesCarousel({ className }: ValuesCarouselProps) {
             'linear-gradient(to top, rgba(var(--color-olive-rgb) / 1), rgba(var(--color-olive-rgb) / 0.85), rgba(var(--color-olive-rgb) / 0))',
         }}
       />
+      <div className="relative z-10 px-6 pt-10">
+        <h2 className="text-center text-3xl font-semibold text-antique md:text-4xl">
+          Values, Culture &amp; Beliefs
+        </h2>
+      </div>
       <div
         ref={containerRef}
-        className="no-scrollbar h-full snap-y snap-mandatory overflow-y-scroll scroll-smooth py-12"
+        className="no-scrollbar h-full snap-y snap-mandatory overflow-y-scroll scroll-smooth pb-12 pt-6"
       >
         {slides.map((slide, i) => {
           const distance = Math.abs(index - i);
           const opacity = 1 - Math.min(distance * 0.4, 0.8);
+          const showHeading =
+            i === 0 || slides[i - 1]?.groupHeading !== slide.groupHeading;
           return (
             <section key={slide.title} className="snap-center py-4">
+              {showHeading && (
+                <p className="mb-3 text-sm font-semibold uppercase tracking-wide text-antique/80">
+                  {slide.groupHeading}
+                </p>
+              )}
               <motion.div
                 initial={{ opacity: 0, y: 20 }}
                 animate={{ opacity: 1, y: 0 }}

--- a/src/components/about/ValuesCarousel.tsx
+++ b/src/components/about/ValuesCarousel.tsx
@@ -139,7 +139,9 @@ export default function ValuesCarousel({ className }: ValuesCarouselProps) {
     (group: SlideGroup, index: number, behavior: ScrollBehavior = 'smooth') => {
       const container = groupRefs.current[group.heading];
       if (!container) return;
-      const card = container.children[index] as HTMLElement | undefined;
+      const card = container.querySelector<HTMLElement>(
+        `[data-card-index="${index}"]`,
+      );
       if (!card) return;
 
       if (group.axis === 'x') {
@@ -329,6 +331,10 @@ export default function ValuesCarousel({ className }: ValuesCarouselProps) {
             const activeIndex = activeIndices[group.heading] ?? 0;
             const isHorizontal = group.axis === 'x';
             const isActiveStage = index === currentStage;
+            const spacerClass = clsx(
+              'pointer-events-none snap-none self-stretch',
+              'flex-[0_0_50%] shrink-0',
+            );
             const containerClasses = clsx(
               'group/card no-scrollbar flex gap-6',
               'min-h-0 flex-1',
@@ -361,17 +367,29 @@ export default function ValuesCarousel({ className }: ValuesCarouselProps) {
                   }}
                   className={containerClasses}
                 >
+                  <div aria-hidden className={spacerClass} />
                   {group.cards.map((card, cardIndex) => {
                     const distance = Math.abs(activeIndex - cardIndex);
                     const opacity = 1 - Math.min(distance * 0.4, 0.8);
                     const motionConfig = motionConfigs[group.motionKey];
+                    const isCulture = group.motionKey === 'culture';
+                    const scale = isCulture
+                      ? Math.max(0.86, 1 - distance * 0.08)
+                      : 1;
+                    const cardInitial = isCulture
+                      ? { ...motionConfig.initial, scale }
+                      : motionConfig.initial;
+                    const cardAnimate = isCulture
+                      ? { ...motionConfig.animate, scale }
+                      : motionConfig.animate;
                     return (
                       <motion.div
                         key={card.title}
-                        initial={motionConfig.initial}
-                        animate={motionConfig.animate}
+                        data-card-index={cardIndex}
+                        initial={cardInitial}
+                        animate={cardAnimate}
                         transition={motionConfig.transition}
-                        style={{ opacity }}
+                        style={{ opacity, transformOrigin: 'center center' }}
                         className={clsx(
                           'snap-center rounded-xl bg-antique p-6 text-charcoal shadow-silver/20',
                           isHorizontal && 'min-w-[calc(100%-1.5rem)] shrink-0',
@@ -383,6 +401,7 @@ export default function ValuesCarousel({ className }: ValuesCarouselProps) {
                       </motion.div>
                     );
                   })}
+                  <div aria-hidden className={spacerClass} />
                 </div>
               </section>
             );


### PR DESCRIPTION
## Summary
- replace the flat values carousel data with grouped collections for values, culture, and beliefs
- render a unified section heading with per-group subheadings while preserving existing card styling

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6907f489d5808328b7e2f4b05bcfcba4